### PR TITLE
Feat/enclave bootstrap server

### DIFF
--- a/cmd/swisstronikd/cmd/enclave.go
+++ b/cmd/swisstronikd/cmd/enclave.go
@@ -94,12 +94,15 @@ func CreateMasterKey() *cobra.Command {
 // StartAttestationServer returns start-attestation-server cobra Command.
 func StartAttestationServer() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "start-attestation-server [port]",
+		Use: "start-attestation-server [address-with-port]",
 		Short: "Starts attestation server",
 		Long: "Start server for Intel SGX Remote Attestation to share master key with new nodes",
-		Args: cobra.ExactArgs(2),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			if err := librustgo.StartSeedServer(args[0]); err != nil {
+				return err
+			}
+			return server.WaitForQuitSignals()
 		},
 	}
 

--- a/cmd/swisstronikd/cmd/enclave.go
+++ b/cmd/swisstronikd/cmd/enclave.go
@@ -13,6 +13,20 @@ import (
 
 const flagShouldReset = "reset"
 
+// Cmd creates a CLI main command
+func EnclaveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enclave",
+		Short: "Commands for interaction with Swisstronik SGX Enclave",
+		RunE:  client.ValidateCmd,
+	}
+
+	cmd.AddCommand(RequestMasterKeyCmd())
+	cmd.AddCommand(CreateMasterKey())
+
+	return cmd
+}
+
 // RequestMasterKeyCmd returns request-master-key cobra Command.
 func RequestMasterKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/swisstronikd/cmd/enclave.go
+++ b/cmd/swisstronikd/cmd/enclave.go
@@ -23,6 +23,7 @@ func EnclaveCmd() *cobra.Command {
 
 	cmd.AddCommand(RequestMasterKeyCmd())
 	cmd.AddCommand(CreateMasterKey())
+	cmd.AddCommand(StartAttestationServer())
 
 	return cmd
 }
@@ -86,6 +87,21 @@ func CreateMasterKey() *cobra.Command {
 	}
 
 	cmd.Flags().Bool(flagShouldReset, false, "reset already existing master key. Default: false")
+
+	return cmd
+}
+
+// StartAttestationServer returns start-attestation-server cobra Command.
+func StartAttestationServer() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "start-attestation-server [port]",
+		Short: "Starts attestation server",
+		Long: "Start server for Intel SGX Remote Attestation to share master key with new nodes",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
 
 	return cmd
 }

--- a/cmd/swisstronikd/cmd/root.go
+++ b/cmd/swisstronikd/cmd/root.go
@@ -128,8 +128,7 @@ func initRootCmd(
 		evmmoduleclient.NewTestnetCmd(app.ModuleBasics, banktypes.GenesisBalancesIterator{}),
 		debug.Cmd(),
 		config.Cmd(),
-		RequestMasterKeyCmd(),
-		CreateMasterKey(),
+		EnclaveCmd(),
 		// this line is used by starport scaffolding # root/commands
 	)
 


### PR DESCRIPTION
- Add `start-attestation-server` command
- Add root command `enclave` and make all enclave-related commands as its subcommands