### PR TITLE
Update ERC20Token.sol

### DIFF
--- a/tests/solidity/contracts/ERC20Token.sol
+++ b/tests/solidity/contracts/ERC20Token.sol
@@ -4,11 +4,19 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract ERC20Token is ERC20 {
+    address private owner;
+
     constructor(string memory name, string memory symbol, uint256 initialSupply) ERC20(name, symbol) {
         _mint(msg.sender, initialSupply);
+        owner = msg.sender;
     }
 
-    function mint(address to, uint256 amount) public {
+    function private_mint(address to, uint256 amount) private {
         _mint(to, amount);
+    }
+
+    function public_mint(address to, uint256 amount) public {
+        require(msg.sender == owner, "Only the owner can call public_mint");
+        private_mint(to, amount);
     }
 }


### PR DESCRIPTION
Make the mint function visibility to private , and create another function that allows only deployer can mint.

Because if using public in function mint, the token can be minted by anyone, so it will be a security risk to this contract, and when mainnet launch this function can cause the price goes down because token supply can be minted by anyone from outside the contract.

Instead using public function you can use private function to set the visibility into private, to set the "mint" function can only be called within the contract itself not from outside.

If the deployer want to mint the token using private function, he can calling it with another function.