### PR TITLE
feat/msg.sender

### DIFF
--- a/tests/solidity/contracts/Sender.sol
+++ b/tests/solidity/contracts/Sender.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8;
+
+contract Sender {
+    function getSender() public view returns (address) {
+        return msg.sender;
+    }
+}

--- a/tests/solidity/test/Sender.js
+++ b/tests/solidity/test/Sender.js
@@ -31,7 +31,6 @@ describe('Recover sender in query', () => {
             senderWallet,
             senderContract.address,
             senderContract.interface.encodeFunctionData("getSender", []),
-            0
         );
     
         const result = senderContract.interface.decodeFunctionResult("getSender", req)[0]

--- a/tests/solidity/test/Sender.js
+++ b/tests/solidity/test/Sender.js
@@ -1,0 +1,40 @@
+const { expect } = require('chai')
+const { sendSignedShieldedQuery, sendShieldedQuery } = require("./testUtils")
+const { ethers } = require("hardhat")
+
+describe('Recover sender in query', () => {
+    let signer, senderContract
+
+    before(async () => {
+        const [ethersSigner] = await ethers.getSigners()
+        signer = ethersSigner
+
+        const SenderContract = await ethers.getContractFactory('Sender')
+        senderContract = await SenderContract.deploy()
+        await senderContract.deployed()
+    })
+
+    it('Should return empty msg.sender if was not signed', async () => {
+        const emptySenderRequest = await sendShieldedQuery(
+            ethers.provider,
+            senderContract.address,
+            senderContract.interface.encodeFunctionData("getSender", [])
+        );
+    
+        const emptySenderResult = senderContract.interface.decodeFunctionResult("getSender", emptySenderRequest)[0]
+        expect(emptySenderResult).to.be.equal(ethers.constants.AddressZero)
+    })
+
+    it('Should return signer address', async () => {
+        const senderWallet = ethers.Wallet.createRandom().connect(signer.provider)
+        const req = await sendSignedShieldedQuery(
+            senderWallet,
+            senderContract.address,
+            senderContract.interface.encodeFunctionData("getSender", []),
+            0
+        );
+    
+        const result = senderContract.interface.decodeFunctionResult("getSender", req)[0]
+        expect(result).to.be.equal(senderWallet.address)
+    })
+})

--- a/tests/solidity/test/testUtils.js
+++ b/tests/solidity/test/testUtils.js
@@ -52,7 +52,6 @@ module.exports.sendSignedShieldedQuery = async (wallet, destination, data) => {
 
     // We treat signed call as a transaction, but it will be sent using eth_call
     const callData = {
-        from: wallet.address,
         to: destination,
         data: encryptedData,
         chainId: networkInfo.chainId,
@@ -64,7 +63,6 @@ module.exports.sendSignedShieldedQuery = async (wallet, destination, data) => {
 
     // Construct call with signature values
     const signedCallData = {
-        from: wallet.address,
         to: decoded.to,
         data: decoded.data,
         v: ethers.utils.hexValue(decoded.v),


### PR DESCRIPTION
- Add possibility to provide signature within `eth_call`
- Restore msg.sender in `eth_call` from signature or use `0x000..0000` address
- Add `utils` JSON-RPC namespace with `utils_convertAddress` method which can be used to convert bech32 addresses to hex and vice versa  
- Enable `eth_getStorageAt` method