### PR TITLE
Fix denom prefix from uswtr -> aswtr

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -354,7 +354,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),
@@ -384,7 +384,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),
@@ -414,7 +414,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),
@@ -469,7 +469,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),
@@ -499,7 +499,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),
@@ -529,7 +529,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),
@@ -559,7 +559,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),
@@ -592,7 +592,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),
@@ -621,7 +621,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"uswtr",
+							"aswtr",
 							sdk.NewInt(1),
 						),
 					),

--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -25,6 +25,7 @@ import (
 	"swisstronik/crypto/ethsecp256k1"
 	"swisstronik/encoding"
 	"swisstronik/tests"
+	"swisstronik/utils"
 	evmtypes "swisstronik/x/evm/types"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -354,7 +355,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),
@@ -384,7 +385,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),
@@ -414,7 +415,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),
@@ -469,7 +470,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),
@@ -499,7 +500,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),
@@ -529,7 +530,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),
@@ -559,7 +560,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),
@@ -592,7 +593,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),
@@ -621,7 +622,7 @@ func (suite AnteTestSuite) TestAnteHandler() {
 					addr[:],
 					sdk.NewCoins(
 						sdk.NewCoin(
-							"aswtr",
+							utils.BaseDenom,
 							sdk.NewInt(1),
 						),
 					),

--- a/app/ante/fee_checker_test.go
+++ b/app/ante/fee_checker_test.go
@@ -52,7 +52,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 	//      without extension option
 	//      london hardfork enableness
 	encodingConfig := encoding.MakeConfig(module.NewBasicManager())
-	minGasPrices := sdk.NewDecCoins(sdk.NewDecCoin("uswtr", sdk.NewInt(10)))
+	minGasPrices := sdk.NewDecCoins(sdk.NewDecCoin("aswtr", sdk.NewInt(10)))
 
 	genesisCtx := sdk.NewContext(nil, tmproto.Header{}, false, log.NewNopLogger())
 	checkTxCtx := sdk.NewContext(nil, tmproto.Header{Height: 1}, true, log.NewNopLogger()).WithMinGasPrices(minGasPrices)
@@ -96,10 +96,10 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder()
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("uswtr", sdk.NewInt(10))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10))))
 				return txBuilder.GetTx()
 			},
-			"10uswtr",
+			"10aswtr",
 			0,
 			true,
 		},
@@ -138,10 +138,10 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder()
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("uswtr", sdk.NewInt(10))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10))))
 				return txBuilder.GetTx()
 			},
-			"10uswtr",
+			"10aswtr",
 			0,
 			true,
 		},
@@ -154,10 +154,10 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder()
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("uswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction).Add(sdk.NewInt(10)))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction).Add(sdk.NewInt(10)))))
 				return txBuilder.GetTx()
 			},
-			"10000010uswtr",
+			"10000010aswtr",
 			10,
 			true,
 		},
@@ -170,14 +170,14 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder().(authtx.ExtensionOptionsTxBuilder)
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("uswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction))))
 
 				option, err := codectypes.NewAnyWithValue(&ethermint.ExtensionOptionDynamicFeeTx{})
 				require.NoError(t, err)
 				txBuilder.SetExtensionOptions(option)
 				return txBuilder.GetTx()
 			},
-			"10uswtr",
+			"10aswtr",
 			0,
 			true,
 		},
@@ -190,7 +190,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder().(authtx.ExtensionOptionsTxBuilder)
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("uswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction).Add(sdk.NewInt(10)))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction).Add(sdk.NewInt(10)))))
 
 				option, err := codectypes.NewAnyWithValue(&ethermint.ExtensionOptionDynamicFeeTx{
 					MaxPriorityPrice: sdk.NewInt(5).Mul(types.DefaultPriorityReduction),
@@ -199,7 +199,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 				txBuilder.SetExtensionOptions(option)
 				return txBuilder.GetTx()
 			},
-			"5000010uswtr",
+			"5000010aswtr",
 			5,
 			true,
 		},

--- a/app/ante/fee_checker_test.go
+++ b/app/ante/fee_checker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"swisstronik/encoding"
 	ethermint "swisstronik/types"
+	"swisstronik/utils"
 	"swisstronik/x/evm/types"
 	evmtypes "swisstronik/x/evm/types"
 )
@@ -52,7 +53,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 	//      without extension option
 	//      london hardfork enableness
 	encodingConfig := encoding.MakeConfig(module.NewBasicManager())
-	minGasPrices := sdk.NewDecCoins(sdk.NewDecCoin("aswtr", sdk.NewInt(10)))
+	minGasPrices := sdk.NewDecCoins(sdk.NewDecCoin(utils.BaseDenom, sdk.NewInt(10)))
 
 	genesisCtx := sdk.NewContext(nil, tmproto.Header{}, false, log.NewNopLogger())
 	checkTxCtx := sdk.NewContext(nil, tmproto.Header{Height: 1}, true, log.NewNopLogger()).WithMinGasPrices(minGasPrices)
@@ -96,7 +97,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder()
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, sdk.NewInt(10))))
 				return txBuilder.GetTx()
 			},
 			"10aswtr",
@@ -138,7 +139,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder()
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, sdk.NewInt(10))))
 				return txBuilder.GetTx()
 			},
 			"10aswtr",
@@ -154,7 +155,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder()
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction).Add(sdk.NewInt(10)))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, sdk.NewInt(10).Mul(types.DefaultPriorityReduction).Add(sdk.NewInt(10)))))
 				return txBuilder.GetTx()
 			},
 			"10000010aswtr",
@@ -170,7 +171,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder().(authtx.ExtensionOptionsTxBuilder)
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, sdk.NewInt(10).Mul(types.DefaultPriorityReduction))))
 
 				option, err := codectypes.NewAnyWithValue(&ethermint.ExtensionOptionDynamicFeeTx{})
 				require.NoError(t, err)
@@ -190,7 +191,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			func() sdk.Tx {
 				txBuilder := encodingConfig.TxConfig.NewTxBuilder().(authtx.ExtensionOptionsTxBuilder)
 				txBuilder.SetGasLimit(1)
-				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("aswtr", sdk.NewInt(10).Mul(types.DefaultPriorityReduction).Add(sdk.NewInt(10)))))
+				txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, sdk.NewInt(10).Mul(types.DefaultPriorityReduction).Add(sdk.NewInt(10)))))
 
 				option, err := codectypes.NewAnyWithValue(&ethermint.ExtensionOptionDynamicFeeTx{
 					MaxPriorityPrice: sdk.NewInt(5).Mul(types.DefaultPriorityReduction),

--- a/app/app.go
+++ b/app/app.go
@@ -1067,5 +1067,5 @@ func (*App) SimulationManager() *module.SimulationManager {
 
 func RegisterCoinDenominations() {
 	_ = sdk.RegisterDenom("swtr", sdk.OneDec())
-	_ = sdk.RegisterDenom("uswtr", sdk.NewDecWithPrec(1, 18))
+	_ = sdk.RegisterDenom("aswtr", sdk.NewDecWithPrec(1, 18))
 }

--- a/app/utils.go
+++ b/app/utils.go
@@ -52,7 +52,7 @@ const (
 	// TestnetChainID defines the Cascadia EIP155 chain ID for testnet
 	TestnetChainID = "swisstronik_1291"
 	// BaseDenom defines the Cascadia mainnet denomination
-	BaseDenom = "uswtr"
+	BaseDenom = "aswtr"
 )
 
 // DefaultConsensusParams defines the default Tendermint consensus params used in App testing.

--- a/config.yml
+++ b/config.yml
@@ -5,16 +5,16 @@ accounts:
 - name: alice
   mnemonic: "entry garbage bike poem grunt negative easily annual miss happy license blur false fringe program picture inner tape dismiss eagle include quality drill master"
   coins:
-  - 200000000000000000000000000uswtr
+  - 200000000000000000000000000aswtr
   cointype: 60
 - name: bob
   mnemonic: "license hint pulse quiz child night blood reveal scrap cloth winter manual often access duck humble oblige wool pyramid gate pretty rib toss unhappy"
   coins:
-  - 200000000000000000000000000uswtr
+  - 200000000000000000000000000aswtr
   cointype: 60
 - name: jane
   coins:
-    - 200000000000000000000000000uswtr
+    - 200000000000000000000000000aswtr
   mnemonic: "cargo ramp supreme review change various throw air figure humble soft steel slam pole betray inhale already dentist enough away office apple sample glue"
   cointype: 60  
 client:
@@ -23,10 +23,10 @@ client:
 faucet:
   name: bob
   coins:
-  - 500000uswtr
+  - 500000aswtr
 validators:
 - name: alice
-  bonded: 100000000uswtr
+  bonded: 100000000aswtr
 genesis:
   chain_id: "swisstronik_1291-1"
   app_state:
@@ -35,7 +35,7 @@ genesis:
         base_fee: "0"
     staking:
       params:
-        bond_denom: "uswtr"
+        bond_denom: "aswtr"
   consensus_params:
     block:
       max_gas: "20000000"   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,5 +80,5 @@ services:
       - "8999:8999"
     environment:
       - SGX_MODE=SW
-    command: "swisstronikd start --minimum-gas-prices=0uswtr --json-rpc.api eth,txpool,personal,net,debug,web3 --api.enable --enclave.address 0.0.0.0:8999 --json-rpc.address 0.0.0.0:8535 --json-rpc.ws-address 0.0.0.0:8546"
+    command: "swisstronikd start --minimum-gas-prices=0aswtr --json-rpc.api eth,txpool,personal,net,debug,web3 --api.enable --enclave.address 0.0.0.0:8999 --json-rpc.address 0.0.0.0:8535 --json-rpc.ws-address 0.0.0.0:8546"
     restart: always

--- a/ethereum/eip712/eip712_test.go
+++ b/ethereum/eip712/eip712_test.go
@@ -19,6 +19,7 @@ import (
 
 	"swisstronik/app"
 	"swisstronik/encoding"
+	"swisstronik/utils"
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
@@ -114,7 +115,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Standard MsgSend",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -132,7 +133,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Standard MsgVote",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -150,7 +151,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Standard MsgDelegate",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -168,7 +169,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Standard MsgWithdrawDelegationReward",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -185,7 +186,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Two Single-Signer MsgDelegate",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -208,7 +209,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Two MsgVotes with Different Signers",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -231,7 +232,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Empty transaction",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo:          "",
@@ -243,7 +244,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Single-Signer MsgSend + MsgVote",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -267,7 +268,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 			title:   "Fails - Invalid ChainID",
 			chainId: "invalidchainid",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -285,7 +286,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Includes TimeoutHeight",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -304,7 +305,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Single Message / Multi-Signer",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins(utils.BaseDenom, math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",

--- a/ethereum/eip712/eip712_test.go
+++ b/ethereum/eip712/eip712_test.go
@@ -114,7 +114,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Standard MsgSend",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -132,7 +132,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Standard MsgVote",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -150,7 +150,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Standard MsgDelegate",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -168,7 +168,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Standard MsgWithdrawDelegationReward",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -185,7 +185,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Succeeds - Two Single-Signer MsgDelegate",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -208,7 +208,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Two MsgVotes with Different Signers",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -231,7 +231,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Empty transaction",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo:          "",
@@ -243,7 +243,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Single-Signer MsgSend + MsgVote",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -267,7 +267,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 			title:   "Fails - Invalid ChainID",
 			chainId: "invalidchainid",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -285,7 +285,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Includes TimeoutHeight",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",
@@ -304,7 +304,7 @@ func (suite *EIP712TestSuite) TestEIP712SignatureVerification() {
 		{
 			title: "Fails - Single Message / Multi-Signer",
 			fee: txtypes.Fee{
-				Amount:   suite.makeCoins("uswtr", math.NewInt(2000)),
+				Amount:   suite.makeCoins("aswtr", math.NewInt(2000)),
 				GasLimit: 20000,
 			},
 			memo: "",

--- a/ibc/utils_test.go
+++ b/ibc/utils_test.go
@@ -255,9 +255,9 @@ func TestGetReceivedCoin(t *testing.T) {
 			"channel-0",
 			"transfer",
 			"channel-0",
-			"transfer/channel-0/uswtr",
+			"transfer/channel-0/aswtr",
 			"10",
-			sdk.Coin{Denom: "uswtr", Amount: sdk.NewInt(10)},
+			sdk.Coin{Denom: "aswtr", Amount: sdk.NewInt(10)},
 		},
 		{
 			"transfer 2x ibc wrapped coin to destination which is its source",
@@ -295,10 +295,10 @@ func TestGetSentCoin(t *testing.T) {
 		expCoin   sdk.Coin
 	}{
 		{
-			"get unwrapped uswtr coin",
-			"uswtr",
+			"get unwrapped aswtr coin",
+			"aswtr",
 			"10",
-			sdk.Coin{Denom: "uswtr", Amount: sdk.NewInt(10)},
+			sdk.Coin{Denom: "aswtr", Amount: sdk.NewInt(10)},
 		},
 		{
 			"get ibc wrapped uosmo coin",

--- a/ibc/utils_test.go
+++ b/ibc/utils_test.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	teststypes "swisstronik/types/tests"
+	"swisstronik/utils"
 
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
@@ -257,7 +258,7 @@ func TestGetReceivedCoin(t *testing.T) {
 			"channel-0",
 			"transfer/channel-0/aswtr",
 			"10",
-			sdk.Coin{Denom: "aswtr", Amount: sdk.NewInt(10)},
+			sdk.Coin{Denom: utils.BaseDenom, Amount: sdk.NewInt(10)},
 		},
 		{
 			"transfer 2x ibc wrapped coin to destination which is its source",
@@ -296,9 +297,9 @@ func TestGetSentCoin(t *testing.T) {
 	}{
 		{
 			"get unwrapped aswtr coin",
-			"aswtr",
+			utils.BaseDenom,
 			"10",
-			sdk.Coin{Denom: "aswtr", Amount: sdk.NewInt(10)},
+			sdk.Coin{Denom: utils.BaseDenom, Amount: sdk.NewInt(10)},
 		},
 		{
 			"get ibc wrapped uosmo coin",

--- a/indexer/kv_indexer_test.go
+++ b/indexer/kv_indexer_test.go
@@ -41,7 +41,7 @@ func TestKVIndexer(t *testing.T) {
 	clientCtx := client.Context{}.WithTxConfig(encodingConfig.TxConfig).WithCodec(encodingConfig.Codec)
 
 	// build cosmos-sdk wrapper tx
-	tmTx, err := tx.BuildTx(clientCtx.TxConfig.NewTxBuilder(), "uswtr")
+	tmTx, err := tx.BuildTx(clientCtx.TxConfig.NewTxBuilder(), "aswtr")
 	require.NoError(t, err)
 	txBz, err := clientCtx.TxConfig.TxEncoder()(tmTx)
 	require.NoError(t, err)

--- a/indexer/kv_indexer_test.go
+++ b/indexer/kv_indexer_test.go
@@ -9,6 +9,7 @@ import (
 	evmenc "swisstronik/encoding"
 	"swisstronik/indexer"
 	"swisstronik/tests"
+	"swisstronik/utils"
 	"swisstronik/x/evm/types"
 
 	"cosmossdk.io/simapp/params"
@@ -41,7 +42,7 @@ func TestKVIndexer(t *testing.T) {
 	clientCtx := client.Context{}.WithTxConfig(encodingConfig.TxConfig).WithCodec(encodingConfig.Codec)
 
 	// build cosmos-sdk wrapper tx
-	tmTx, err := tx.BuildTx(clientCtx.TxConfig.NewTxBuilder(), "aswtr")
+	tmTx, err := tx.BuildTx(clientCtx.TxConfig.NewTxBuilder(), utils.BaseDenom)
 	require.NoError(t, err)
 	txBz, err := clientCtx.TxConfig.TxEncoder()(tmTx)
 	require.NoError(t, err)

--- a/rpc/backend/backend_suite_test.go
+++ b/rpc/backend/backend_suite_test.go
@@ -184,7 +184,7 @@ func (suite *BackendTestSuite) signAndEncodeEthTx(msgHandleTx *evmtypes.MsgHandl
 	err := msgHandleTx.Sign(ethSigner, signer)
 	suite.Require().NoError(err)
 
-	tx, err := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "uswtr")
+	tx, err := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
 	suite.Require().NoError(err)
 
 	txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()

--- a/rpc/backend/backend_suite_test.go
+++ b/rpc/backend/backend_suite_test.go
@@ -26,6 +26,7 @@ import (
 	"swisstronik/rpc/backend/mocks"
 	rpctypes "swisstronik/rpc/types"
 	"swisstronik/tests"
+	"swisstronik/utils"
 	evmtypes "swisstronik/x/evm/types"
 )
 
@@ -184,7 +185,7 @@ func (suite *BackendTestSuite) signAndEncodeEthTx(msgHandleTx *evmtypes.MsgHandl
 	err := msgHandleTx.Sign(ethSigner, signer)
 	suite.Require().NoError(err)
 
-	tx, err := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
+	tx, err := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), utils.BaseDenom)
 	suite.Require().NoError(err)
 
 	txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()

--- a/rpc/backend/call_tx_test.go
+++ b/rpc/backend/call_tx_test.go
@@ -8,6 +8,7 @@ import (
 	"swisstronik/rpc/backend/mocks"
 	rpctypes "swisstronik/rpc/types"
 	"swisstronik/tests"
+	"swisstronik/utils"
 	evmtypes "swisstronik/x/evm/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -287,7 +288,7 @@ func (suite *BackendTestSuite) TestResend() {
 func (suite *BackendTestSuite) TestSendRawTransaction() {
 	ethTx, bz := suite.buildEthereumTx()
 	rlpEncodedBz, _ := rlp.EncodeToBytes(ethTx.AsTransaction())
-	cosmosTx, _ := ethTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
+	cosmosTx, _ := ethTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), utils.BaseDenom)
 	txBytes, _ := suite.backend.clientCtx.TxConfig.TxEncoder()(cosmosTx)
 
 	testCases := []struct {

--- a/rpc/backend/call_tx_test.go
+++ b/rpc/backend/call_tx_test.go
@@ -287,7 +287,7 @@ func (suite *BackendTestSuite) TestResend() {
 func (suite *BackendTestSuite) TestSendRawTransaction() {
 	ethTx, bz := suite.buildEthereumTx()
 	rlpEncodedBz, _ := rlp.EncodeToBytes(ethTx.AsTransaction())
-	cosmosTx, _ := ethTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "uswtr")
+	cosmosTx, _ := ethTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
 	txBytes, _ := suite.backend.clientCtx.TxConfig.TxEncoder()(cosmosTx)
 
 	testCases := []struct {

--- a/rpc/backend/node_info_test.go
+++ b/rpc/backend/node_info_test.go
@@ -255,7 +255,7 @@ func (suite *BackendTestSuite) TestSetEtherbase() {
 				RegisterStatus(client)
 				RegisterValidatorAccount(queryClient, suite.acc)
 				RegisterParams(queryClient, &header, 1)
-				c := sdk.NewDecCoin("uswtr", sdk.NewIntFromBigInt(big.NewInt(1)))
+				c := sdk.NewDecCoin("aswtr", sdk.NewIntFromBigInt(big.NewInt(1)))
 				suite.backend.cfg.SetMinGasPrices(sdk.DecCoins{c})
 				delAddr, _ := suite.backend.GetCoinbase()
 				// account, _ := suite.backend.clientCtx.AccountRetriever.GetAccount(suite.backend.clientCtx, delAddr)

--- a/rpc/backend/node_info_test.go
+++ b/rpc/backend/node_info_test.go
@@ -15,6 +15,7 @@ import (
 	"swisstronik/crypto/ethsecp256k1"
 	"swisstronik/rpc/backend/mocks"
 	ethermint "swisstronik/types"
+	"swisstronik/utils"
 )
 
 func (suite *BackendTestSuite) TestRPCMinGasPrice() {
@@ -255,7 +256,7 @@ func (suite *BackendTestSuite) TestSetEtherbase() {
 				RegisterStatus(client)
 				RegisterValidatorAccount(queryClient, suite.acc)
 				RegisterParams(queryClient, &header, 1)
-				c := sdk.NewDecCoin("aswtr", sdk.NewIntFromBigInt(big.NewInt(1)))
+				c := sdk.NewDecCoin(utils.BaseDenom, sdk.NewIntFromBigInt(big.NewInt(1)))
 				suite.backend.cfg.SetMinGasPrices(sdk.DecCoins{c})
 				delAddr, _ := suite.backend.GetCoinbase()
 				// account, _ := suite.backend.clientCtx.AccountRetriever.GetAccount(suite.backend.clientCtx, delAddr)

--- a/rpc/backend/sign_tx_test.go
+++ b/rpc/backend/sign_tx_test.go
@@ -6,6 +6,7 @@ import (
 	"swisstronik/crypto/ethsecp256k1"
 	"swisstronik/rpc/backend/mocks"
 	"swisstronik/tests"
+	"swisstronik/utils"
 	evmtypes "swisstronik/x/evm/types"
 
 	"github.com/cosmos/cosmos-sdk/crypto"
@@ -114,7 +115,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				msg := callArgsDefault.ToTransaction()
 				err = msg.Sign(ethSigner, suite.backend.clientCtx.Keyring)
 				suite.Require().NoError(err)
-				tx, _ := msg.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
+				tx, _ := msg.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), utils.BaseDenom)
 				txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()
 				txBytes, _ := txEncoder(tx)
 				RegisterBroadcastTxError(client, txBytes)
@@ -143,7 +144,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				msg := callArgsDefault.ToTransaction()
 				err = msg.Sign(ethSigner, suite.backend.clientCtx.Keyring)
 				suite.Require().NoError(err)
-				tx, _ := msg.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
+				tx, _ := msg.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), utils.BaseDenom)
 				txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()
 				txBytes, _ := txEncoder(tx)
 

--- a/rpc/backend/sign_tx_test.go
+++ b/rpc/backend/sign_tx_test.go
@@ -114,7 +114,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				msg := callArgsDefault.ToTransaction()
 				err = msg.Sign(ethSigner, suite.backend.clientCtx.Keyring)
 				suite.Require().NoError(err)
-				tx, _ := msg.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "uswtr")
+				tx, _ := msg.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
 				txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()
 				txBytes, _ := txEncoder(tx)
 				RegisterBroadcastTxError(client, txBytes)
@@ -143,7 +143,7 @@ func (suite *BackendTestSuite) TestSendTransaction() {
 				msg := callArgsDefault.ToTransaction()
 				err = msg.Sign(ethSigner, suite.backend.clientCtx.Keyring)
 				suite.Require().NoError(err)
-				tx, _ := msg.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "uswtr")
+				tx, _ := msg.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
 				txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()
 				txBytes, _ := txEncoder(tx)
 

--- a/rpc/backend/tracing_test.go
+++ b/rpc/backend/tracing_test.go
@@ -6,6 +6,7 @@ import (
 	"swisstronik/crypto/ethsecp256k1"
 	"swisstronik/indexer"
 	"swisstronik/rpc/backend/mocks"
+	"swisstronik/utils"
 	evmtypes "swisstronik/x/evm/types"
 
 	dbm "github.com/cometbft/cometbft-db"
@@ -40,12 +41,12 @@ func (suite *BackendTestSuite) TestTraceTransaction() {
 
 	msgHandleTx.From = from.String()
 	msgHandleTx.Sign(ethSigner, suite.signer)
-	tx, _ := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
+	tx, _ := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), utils.BaseDenom)
 	txBz, _ := txEncoder(tx)
 
 	msgHandleTx2.From = from.String()
 	msgHandleTx2.Sign(ethSigner, suite.signer)
-	tx2, _ := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
+	tx2, _ := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), utils.BaseDenom)
 	txBz2, _ := txEncoder(tx2)
 
 	testCases := []struct {

--- a/rpc/backend/tracing_test.go
+++ b/rpc/backend/tracing_test.go
@@ -40,12 +40,12 @@ func (suite *BackendTestSuite) TestTraceTransaction() {
 
 	msgHandleTx.From = from.String()
 	msgHandleTx.Sign(ethSigner, suite.signer)
-	tx, _ := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "uswtr")
+	tx, _ := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
 	txBz, _ := txEncoder(tx)
 
 	msgHandleTx2.From = from.String()
 	msgHandleTx2.Sign(ethSigner, suite.signer)
-	tx2, _ := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "uswtr")
+	tx2, _ := msgHandleTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
 	txBz2, _ := txEncoder(tx2)
 
 	testCases := []struct {

--- a/scripts/install-gen-node.sh
+++ b/scripts/install-gen-node.sh
@@ -23,16 +23,16 @@ echo "exotic merit wrestle sad bundle age purity ability collect immense place t
 echo "faculty head please solid picnic benefit hurt gloom flag transfer thrive zebra" | swisstronikd keys add validator4 --keyring-backend test --recover
 echo "betray theory cargo way left cricket doll room donkey wire reunion fall left surprise hamster corn village happy bulb token artist twelve whisper expire" | swisstronikd keys add test1 --keyring-backend test --recover
 echo "toss sense candy point cost rookie jealous snow ankle electric sauce forward oblige tourist stairs horror grunt tenant afford master violin final genre reason" | swisstronikd keys add test2 --keyring-backend test --recover
-swisstronikd add-genesis-account $(swisstronikd keys show validator -a --keyring-backend test) 100000000000000000000000uswtr
-swisstronikd add-genesis-account $(swisstronikd keys show validator1 -a --keyring-backend test) 110000000000000000000000uswtr
-swisstronikd add-genesis-account $(swisstronikd keys show validator2 -a --keyring-backend test) 120000000000000000000000uswtr
-swisstronikd add-genesis-account $(swisstronikd keys show validator3 -a --keyring-backend test) 130000000000000000000000uswtr
-swisstronikd add-genesis-account $(swisstronikd keys show validator4 -a --keyring-backend test) 140000000000000000000000uswtr
-swisstronikd add-genesis-account $(swisstronikd keys show test1 -a --keyring-backend test) 10000000000000000000000uswtr
-swisstronikd add-genesis-account $(swisstronikd keys show test2 -a --keyring-backend test) 10000000000000000000000uswtr
-swisstronikd gentx validator 90000000000000000000000uswtr --keyring-backend test --chain-id swisstronik_1291-1
+swisstronikd add-genesis-account $(swisstronikd keys show validator -a --keyring-backend test) 100000000000000000000000aswtr
+swisstronikd add-genesis-account $(swisstronikd keys show validator1 -a --keyring-backend test) 110000000000000000000000aswtr
+swisstronikd add-genesis-account $(swisstronikd keys show validator2 -a --keyring-backend test) 120000000000000000000000aswtr
+swisstronikd add-genesis-account $(swisstronikd keys show validator3 -a --keyring-backend test) 130000000000000000000000aswtr
+swisstronikd add-genesis-account $(swisstronikd keys show validator4 -a --keyring-backend test) 140000000000000000000000aswtr
+swisstronikd add-genesis-account $(swisstronikd keys show test1 -a --keyring-backend test) 10000000000000000000000aswtr
+swisstronikd add-genesis-account $(swisstronikd keys show test2 -a --keyring-backend test) 10000000000000000000000aswtr
+swisstronikd gentx validator 90000000000000000000000aswtr --keyring-backend test --chain-id swisstronik_1291-1
 swisstronikd collect-gentxs
-sed -i 's/stake/uswtr/g' "$GENESIS"
+sed -i 's/stake/aswtr/g' "$GENESIS"
 sed -i 's/pruning = "default"/pruning = "custom"/g' "$CONFIG"
 sed -i 's/pruning-keep-recent = "0"/pruning-keep-recent = "2"/g' "$APP_TOML"
 sed -i 's/pruning-interval = "0"/pruning-interval = "10"/g' "$APP_TOML"
@@ -40,6 +40,6 @@ sed -i 's/127.0.0.1:26657/0.0.0.0:26657/g' "$CONFIG"
 sed -i 's/cors_allowed_origins\s*=\s*\[\]/cors_allowed_origins = ["*",]/g' "$CONFIG"
 # Enable prometheus on genesis node
 sed -i 's/prometheus = false/prometheus = true/g' "$CONFIG"
-jq '.app_state["evm"]["params"]["evm_denom"]="uswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.app_state["evm"]["params"]["evm_denom"]="aswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 jq '.consensus_params["block"]["max_gas"]="10000000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 jq '.app_state["feemarket"]["last_block_gas"]="10000000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"

--- a/scripts/local-node.sh
+++ b/scripts/local-node.sh
@@ -31,11 +31,11 @@ echo "toss sense candy point cost rookie jealous snow ankle electric sauce forwa
 
 swisstronikd init $MONIKER -o --chain-id $CHAINID --home "$HOMEDIR"
 
-jq '.app_state["staking"]["params"]["bond_denom"]="uswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-jq '.app_state["crisis"]["constant_fee"]["denom"]="uswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="uswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-jq '.app_state["evm"]["params"]["evm_denom"]="uswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-jq '.app_state["inflation"]["params"]["mint_denom"]="uswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.app_state["staking"]["params"]["bond_denom"]="aswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.app_state["crisis"]["constant_fee"]["denom"]="aswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="aswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.app_state["evm"]["params"]["evm_denom"]="aswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+jq '.app_state["inflation"]["params"]["mint_denom"]="aswtr"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 jq '.consensus_params["block"]["max_gas"]="10000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 
 # expose ports
@@ -49,7 +49,7 @@ sed -i 's/prometheus-retention-time  = "0"/prometheus-retention-time  = "1000000
 sed -i 's/enabled = false/enabled = true/g' "$APP_TOML"
 
 # set min gas price
-sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0uswtr"/' "$APP_TOML"
+sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0aswtr"/' "$APP_TOML"
 
 # Change proposal periods to pass within a reasonable time for local testing
 sed -i.bak 's/"max_deposit_period": "172800s"/"max_deposit_period": "30s"/g' "$HOMEDIR"/config/genesis.json
@@ -61,11 +61,11 @@ sed -i.bak 's/pruning-keep-recent = "0"/pruning-keep-recent = "2"/g' "$APP_TOML"
 sed -i.bak 's/pruning-interval = "0"/pruning-interval = "10"/g' "$APP_TOML"
 
 # Allocate genesis accounts
-swisstronikd add-genesis-account alice 10000000000000000000000000uswtr --keyring-backend $KEYRING --home "$HOMEDIR"
-swisstronikd add-genesis-account bob 10000000000000000000000000uswtr --keyring-backend $KEYRING --home "$HOMEDIR"
+swisstronikd add-genesis-account alice 10000000000000000000000000aswtr --keyring-backend $KEYRING --home "$HOMEDIR"
+swisstronikd add-genesis-account bob 10000000000000000000000000aswtr --keyring-backend $KEYRING --home "$HOMEDIR"
 
 # Sign genesis transaction
-swisstronikd gentx alice 1000000000000000000000uswtr --keyring-backend $KEYRING --chain-id $CHAINID --home "$HOMEDIR"
+swisstronikd gentx alice 1000000000000000000000aswtr --keyring-backend $KEYRING --chain-id $CHAINID --home "$HOMEDIR"
 
 # Collect genesis tx
 swisstronikd collect-gentxs --home "$HOMEDIR"

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -89,8 +89,8 @@ const (
 func AddTxFlags(cmd *cobra.Command) (*cobra.Command, error) {
 	cmd.PersistentFlags().String(flags.FlagChainID, "", "Specify Chain ID for sending Tx")
 	cmd.PersistentFlags().String(flags.FlagFrom, "", "Name or address of private key with which to sign")
-	cmd.PersistentFlags().String(flags.FlagFees, "", "Fees to pay along with transaction; eg: 10uswtr")
-	cmd.PersistentFlags().String(flags.FlagGasPrices, "", "Gas prices to determine the transaction fee (e.g. 10uswtr)")
+	cmd.PersistentFlags().String(flags.FlagFees, "", "Fees to pay along with transaction; eg: 10aswtr")
+	cmd.PersistentFlags().String(flags.FlagGasPrices, "", "Gas prices to determine the transaction fee (e.g. 10aswtr)")
 	cmd.PersistentFlags().String(flags.FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")                                                                                                   //nolint:lll
 	cmd.PersistentFlags().Float64(flags.FlagGasAdjustment, flags.DefaultGasAdjustment, "adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored ") //nolint:lll
 	cmd.PersistentFlags().StringP(flags.FlagBroadcastMode, "b", flags.BroadcastSync, "Transaction broadcasting mode (sync|async|block)")

--- a/server/start.go
+++ b/server/start.go
@@ -213,7 +213,7 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().StringSlice(srvflags.JSONRPCAPI, config.GetDefaultAPINamespaces(), "Defines a list of JSON-RPC namespaces that should be enabled")
 	cmd.Flags().String(srvflags.JSONRPCAddress, config.DefaultJSONRPCAddress, "the JSON-RPC server address to listen on")
 	cmd.Flags().String(srvflags.JSONWsAddress, config.DefaultJSONRPCWsAddress, "the JSON-RPC WS server address to listen on")
-	cmd.Flags().Uint64(srvflags.JSONRPCGasCap, config.DefaultGasCap, "Sets a cap on gas that can be used in eth_call/estimateGas unit is uswtr (0=infinite)")       //nolint:lll
+	cmd.Flags().Uint64(srvflags.JSONRPCGasCap, config.DefaultGasCap, "Sets a cap on gas that can be used in eth_call/estimateGas unit is aswtr (0=infinite)")       //nolint:lll
 	cmd.Flags().Float64(srvflags.JSONRPCTxFeeCap, config.DefaultTxFeeCap, "Sets a cap on transaction fee that can be sent via the RPC APIs (1 = default 1 photon)") //nolint:lll
 	cmd.Flags().Int32(srvflags.JSONRPCFilterCap, config.DefaultFilterCap, "Sets the global cap for total number of filters that can be created")
 	cmd.Flags().Duration(srvflags.JSONRPCEVMTimeout, config.DefaultEVMTimeout, "Sets a timeout used for eth_call (0=infinite)")

--- a/types/coin.go
+++ b/types/coin.go
@@ -31,10 +31,10 @@ const (
 	// - Governance parameters: denomination used for spam prevention in proposal deposits
 	// - Crisis parameters: constant fee denomination used for spam prevention to check broken invariant
 	// - EVM parameters: denomination used for running EVM state transitions in Swisstronik.
-	SwtrDenom string = "uswtr"
+	SwtrDenom string = "aswtr"
 
 	// BaseDenomUnit defines the base denomination unit for SWTR.
-	// 1 photon = 1x10^{BaseDenomUnit} uswtr
+	// 1 photon = 1x10^{BaseDenomUnit} aswtr
 	BaseDenomUnit = 18
 
 	// DefaultGasPrice is default gas price for evm transactions
@@ -44,19 +44,19 @@ const (
 // PowerReduction defines the default power reduction value for staking
 var PowerReduction = sdkmath.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(BaseDenomUnit), nil))
 
-// NewPhotonCoin is a utility function that returns an "uswtr" coin with the given sdkmath.Int amount.
+// NewPhotonCoin is a utility function that returns an "aswtr" coin with the given sdkmath.Int amount.
 // The function will panic if the provided amount is negative.
 func NewPhotonCoin(amount sdkmath.Int) sdk.Coin {
 	return sdk.NewCoin(SwtrDenom, amount)
 }
 
-// NewPhotonDecCoin is a utility function that returns an "uswtr" decimal coin with the given sdkmath.Int amount.
+// NewPhotonDecCoin is a utility function that returns an "aswtr" decimal coin with the given sdkmath.Int amount.
 // The function will panic if the provided amount is negative.
 func NewPhotonDecCoin(amount sdkmath.Int) sdk.DecCoin {
 	return sdk.NewDecCoin(SwtrDenom, amount)
 }
 
-// NewPhotonCoinInt64 is a utility function that returns an "uswtr" coin with the given int64 amount.
+// NewPhotonCoinInt64 is a utility function that returns an "aswtr" coin with the given int64 amount.
 // The function will panic if the provided amount is negative.
 func NewPhotonCoinInt64(amount int64) sdk.Coin {
 	return sdk.NewInt64Coin(SwtrDenom, amount)

--- a/types/tests/test_utils.go
+++ b/types/tests/test_utils.go
@@ -35,7 +35,7 @@ var (
 
 	UDenomtrace = transfertypes.DenomTrace{
 		Path:      "transfer/channel-0",
-		BaseDenom: "uswtr",
+		BaseDenom: "aswtr",
 	}
 	UIbcdenom = UDenomtrace.IBCDenom()
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -35,7 +35,7 @@ const (
 	// TestnetChainID defines the EIP155 chain ID for testnet
 	TestnetChainID = "swisstronik_1291"
 	// BaseDenom defines the denomination
-	BaseDenom = "uswtr"
+	BaseDenom = "aswtr"
 )
 
 // IsMainnet returns true if the chain-id has the mainnet EIP155 chain prefix.

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -137,7 +137,7 @@ func TestEvmosCoinDenom(t *testing.T) {
 	}{
 		{
 			"valid denom - native coin",
-			"uswtr",
+			"aswtr",
 			false,
 		},
 		{

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -2,8 +2,6 @@ package evm_test
 
 import (
 	"math/big"
-	"swisstronik/utils"
-	"swisstronik/x/evm/keeper"
 	"testing"
 	"time"
 
@@ -38,7 +36,9 @@ import (
 	"swisstronik/crypto/ethsecp256k1"
 	"swisstronik/tests"
 	evmcommontypes "swisstronik/types"
+	"swisstronik/utils"
 	"swisstronik/x/evm"
+	"swisstronik/x/evm/keeper"
 	"swisstronik/x/evm/types"
 
 	"github.com/cometbft/cometbft/crypto/tmhash"
@@ -616,7 +616,7 @@ func (suite *EvmTestSuite) TestERC20TransferReverted() {
 
 			txData, err := types.UnpackTxData(tx.Data)
 			suite.Require().NoError(err)
-			fees, err := keeper.VerifyFee(txData, "aswtr", baseFee, true, true, suite.ctx.IsCheckTx())
+			fees, err := keeper.VerifyFee(txData, utils.BaseDenom, baseFee, true, true, suite.ctx.IsCheckTx())
 			suite.Require().NoError(err)
 			err = k.DeductTxCostsFromUserBalance(suite.ctx, fees, common.HexToAddress(tx.From))
 			suite.Require().NoError(err)

--- a/x/evm/handler_test.go
+++ b/x/evm/handler_test.go
@@ -616,7 +616,7 @@ func (suite *EvmTestSuite) TestERC20TransferReverted() {
 
 			txData, err := types.UnpackTxData(tx.Data)
 			suite.Require().NoError(err)
-			fees, err := keeper.VerifyFee(txData, "uswtr", baseFee, true, true, suite.ctx.IsCheckTx())
+			fees, err := keeper.VerifyFee(txData, "aswtr", baseFee, true, true, suite.ctx.IsCheckTx())
 			suite.Require().NoError(err)
 			err = k.DeductTxCostsFromUserBalance(suite.ctx, fees, common.HexToAddress(tx.From))
 			suite.Require().NoError(err)

--- a/x/evm/types/msg_test.go
+++ b/x/evm/types/msg_test.go
@@ -103,7 +103,7 @@ func (suite *MsgsTestSuite) TestMsgHandleTx_BuildTx() {
 			tc.msg.Data = nil
 		}
 
-		tx, err := tc.msg.BuildTx(suite.clientCtx.TxConfig.NewTxBuilder(), "uswtr")
+		tx, err := tc.msg.BuildTx(suite.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
 		if tc.expError {
 			suite.Require().Error(err)
 		} else {
@@ -112,7 +112,7 @@ func (suite *MsgsTestSuite) TestMsgHandleTx_BuildTx() {
 			suite.Require().Empty(tx.GetMemo())
 			suite.Require().Empty(tx.GetTimeoutHeight())
 			suite.Require().Equal(uint64(100000), tx.GetGas())
-			suite.Require().Equal(sdk.NewCoins(sdk.NewCoin("uswtr", sdkmath.NewInt(100000))), tx.GetFee())
+			suite.Require().Equal(sdk.NewCoins(sdk.NewCoin("aswtr", sdkmath.NewInt(100000))), tx.GetFee())
 		}
 	}
 }

--- a/x/evm/types/msg_test.go
+++ b/x/evm/types/msg_test.go
@@ -23,6 +23,7 @@ import (
 
 	"swisstronik/app"
 	"swisstronik/encoding"
+	"swisstronik/utils"
 	"swisstronik/x/evm/types"
 )
 
@@ -103,7 +104,7 @@ func (suite *MsgsTestSuite) TestMsgHandleTx_BuildTx() {
 			tc.msg.Data = nil
 		}
 
-		tx, err := tc.msg.BuildTx(suite.clientCtx.TxConfig.NewTxBuilder(), "aswtr")
+		tx, err := tc.msg.BuildTx(suite.clientCtx.TxConfig.NewTxBuilder(), utils.BaseDenom)
 		if tc.expError {
 			suite.Require().Error(err)
 		} else {
@@ -112,7 +113,7 @@ func (suite *MsgsTestSuite) TestMsgHandleTx_BuildTx() {
 			suite.Require().Empty(tx.GetMemo())
 			suite.Require().Empty(tx.GetTimeoutHeight())
 			suite.Require().Equal(uint64(100000), tx.GetGas())
-			suite.Require().Equal(sdk.NewCoins(sdk.NewCoin("aswtr", sdkmath.NewInt(100000))), tx.GetFee())
+			suite.Require().Equal(sdk.NewCoins(sdk.NewCoin(utils.BaseDenom, sdkmath.NewInt(100000))), tx.GetFee())
 		}
 	}
 }

--- a/x/vesting/keeper/msg_server_test.go
+++ b/x/vesting/keeper/msg_server_test.go
@@ -23,8 +23,8 @@ var (
 	to1AddrAcc = sdk.AccAddress([]byte(to1Addr))
 
 	to2Addr    = "swtr13gvyhac4qwtqjkdpzxzarlvpsz3zxld5v2ae58"
-	zeroCoin   = sdk.NewInt64Coin("uswtr", 0)
-	periodCoin = sdk.NewInt64Coin("uswtr", 200000000)
+	zeroCoin   = sdk.NewInt64Coin("aswtr", 0)
+	periodCoin = sdk.NewInt64Coin("aswtr", 200000000)
 )
 
 func TestCreatingMonthlyVestingAccount(t *testing.T) {

--- a/x/vesting/keeper/msg_server_test.go
+++ b/x/vesting/keeper/msg_server_test.go
@@ -23,8 +23,8 @@ var (
 	to1AddrAcc = sdk.AccAddress([]byte(to1Addr))
 
 	to2Addr    = "swtr13gvyhac4qwtqjkdpzxzarlvpsz3zxld5v2ae58"
-	zeroCoin   = sdk.NewInt64Coin("aswtr", 0)
-	periodCoin = sdk.NewInt64Coin("aswtr", 200000000)
+	zeroCoin   = sdk.NewInt64Coin(utils.BaseDenom, 0)
+	periodCoin = sdk.NewInt64Coin(utils.BaseDenom, 200000000)
 )
 
 func TestCreatingMonthlyVestingAccount(t *testing.T) {


### PR DESCRIPTION
The `u` prefix suggests there are 6 points of precision (0.000000), however EVMs run on 18 points of precision, which is denoted by `a`.