### PR TITLE
Add unit tests for x/compliance module

### DIFF
--- a/x/compliance/genesis.go
+++ b/x/compliance/genesis.go
@@ -71,7 +71,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 			if verificationData.VerificationId == nil {
 				panic(errors.Wrap(types.ErrInvalidParam, "verification id is nil"))
 			}
-			if details, err := k.GetVerificationDetails(ctx, verificationData.VerificationId); details == nil || err != nil {
+			if _, err = k.GetVerificationDetails(ctx, verificationData.VerificationId); err != nil {
 				panic(err)
 			}
 		}

--- a/x/compliance/genesis.go
+++ b/x/compliance/genesis.go
@@ -1,7 +1,9 @@
 package compliance
 
 import (
+	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"swisstronik/x/compliance/keeper"
 	"swisstronik/x/compliance/types"
 )
@@ -16,7 +18,36 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 		if err != nil {
 			panic(err)
 		}
+		// Operator address must not be empty
+		if len(issuerData.Details.Operator) < 1 {
+			panic(errors.Wrap(types.ErrInvalidParam, "empty operator of issuer"))
+		}
 		if err := k.SetIssuerDetails(ctx, issuerAddress, issuerData.Details); err != nil {
+			panic(err)
+		}
+	}
+
+	// Restore verification data
+	for _, verificationData := range genState.VerificationDetails {
+		// TODO, Check if issuer address is valid or timestamp of issuance/expiration are valid
+
+		// Check if issuer address is valid
+		issuerAddress, err := sdk.AccAddressFromBech32(verificationData.Details.IssuerAddress)
+		if err != nil {
+			panic(err)
+		}
+		if exists, err := k.IssuerExists(ctx, issuerAddress); !exists || err != nil {
+			panic(err)
+		}
+		// Check the issuance timestamp and proof
+		if verificationData.Details.IssuanceTimestamp >= verificationData.Details.ExpirationTimestamp {
+			panic(errors.Wrap(types.ErrInvalidParam, "invalid issuance timestamp"))
+		}
+		if len(verificationData.Details.OriginalData) < 1 {
+			panic(errors.Wrap(types.ErrInvalidParam, "empty proof data"))
+		}
+
+		if err := k.SetVerificationDetails(ctx, verificationData.Id, verificationData.Details); err != nil {
 			panic(err)
 		}
 	}
@@ -28,14 +59,28 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 			panic(err)
 		}
 
-		if err := k.SetAddressDetails(ctx, address, addressData.Details); err != nil {
-			panic(err)
+		// If address is verified, verification data must exist and issuer must be valid
+		if addressData.Details.IsVerified {
+			for _, verificationData := range addressData.Details.Verifications {
+				// Check if issuer is valid
+				issuerAddress, err := sdk.AccAddressFromBech32(verificationData.IssuerAddress)
+				if err != nil {
+					panic(err)
+				}
+				if exists, err := k.IssuerExists(ctx, issuerAddress); !exists || err != nil {
+					panic(err)
+				}
+				// Check if verification data exists
+				if verificationData.VerificationId == nil {
+					panic(errors.Wrap(types.ErrInvalidParam, "verification id is nil"))
+				}
+				if details, err := k.GetVerificationDetails(ctx, verificationData.VerificationId); details == nil || err != nil {
+					panic(err)
+				}
+			}
 		}
-	}
 
-	// Restore verification data
-	for _, verificationData := range genState.VerificationDetails {
-		if err := k.SetVerificationDetails(ctx, verificationData.Id, verificationData.Details); err != nil {
+		if err := k.SetAddressDetails(ctx, address, addressData.Details); err != nil {
 			panic(err)
 		}
 	}

--- a/x/compliance/genesis.go
+++ b/x/compliance/genesis.go
@@ -29,8 +29,6 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 
 	// Restore verification data
 	for _, verificationData := range genState.VerificationDetails {
-		// TODO, Check if issuer address is valid or timestamp of issuance/expiration are valid
-
 		// Check if issuer address is valid
 		issuerAddress, err := sdk.AccAddressFromBech32(verificationData.Details.IssuerAddress)
 		if err != nil {

--- a/x/compliance/genesis.go
+++ b/x/compliance/genesis.go
@@ -58,23 +58,21 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 		}
 
 		// If address is verified, verification data must exist and issuer must be valid
-		if addressData.Details.IsVerified {
-			for _, verificationData := range addressData.Details.Verifications {
-				// Check if issuer is valid
-				issuerAddress, err := sdk.AccAddressFromBech32(verificationData.IssuerAddress)
-				if err != nil {
-					panic(err)
-				}
-				if exists, err := k.IssuerExists(ctx, issuerAddress); !exists || err != nil {
-					panic(err)
-				}
-				// Check if verification data exists
-				if verificationData.VerificationId == nil {
-					panic(errors.Wrap(types.ErrInvalidParam, "verification id is nil"))
-				}
-				if details, err := k.GetVerificationDetails(ctx, verificationData.VerificationId); details == nil || err != nil {
-					panic(err)
-				}
+		for _, verificationData := range addressData.Details.Verifications {
+			// Check if issuer is valid
+			issuerAddress, err := sdk.AccAddressFromBech32(verificationData.IssuerAddress)
+			if err != nil {
+				panic(err)
+			}
+			if exists, err := k.IssuerExists(ctx, issuerAddress); !exists || err != nil {
+				panic(err)
+			}
+			// Check if verification data exists
+			if verificationData.VerificationId == nil {
+				panic(errors.Wrap(types.ErrInvalidParam, "verification id is nil"))
+			}
+			if details, err := k.GetVerificationDetails(ctx, verificationData.VerificationId); details == nil || err != nil {
+				panic(err)
 			}
 		}
 

--- a/x/compliance/genesis_test.go
+++ b/x/compliance/genesis_test.go
@@ -1,0 +1,255 @@
+package compliance_test
+
+import (
+	"sort"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/status-im/keycard-go/hexutils"
+	"github.com/stretchr/testify/require"
+	
+	testkeeper "swisstronik/testutil/keeper"
+	"swisstronik/x/compliance"
+	"swisstronik/x/compliance/types"
+)
+
+func TestGenesis_Validation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		genState *types.GenesisState
+		expPanic bool
+	}{
+		{
+			name:     "default",
+			genState: types.DefaultGenesis(),
+		},
+		{
+			name: "invalid issuers",
+			genState: &types.GenesisState{
+				Issuers: []*types.IssuerGenesisAccount{
+					{Address: "wrong address"},
+				},
+			},
+			expPanic: true,
+		},
+		{
+			name: "invalid address",
+			genState: &types.GenesisState{
+				AddressDetails: []*types.GenesisAddressDetails{
+					{Address: "wrong address"},
+				},
+			},
+			expPanic: true,
+		},
+		{
+			name:     "not found verification data", // there's no verification data with verification_id
+			genState: &types.GenesisState{},         // todo
+			expPanic: true,
+		},
+		{
+			name:     "invalid issuer in verification data",
+			genState: &types.GenesisState{}, // todo
+			expPanic: true,
+		},
+		{
+			name:     "invalid timestamp in verification data",
+			genState: &types.GenesisState{}, // todo
+			expPanic: true,
+		},
+		{
+			name:     "issuer not found",
+			genState: &types.GenesisState{}, // todo
+			expPanic: true,
+		},
+		{
+			name:     "verification id not valid", // Refer: Keeper.AddVerificationDetails
+			genState: &types.GenesisState{},       // todo
+			expPanic: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			k, ctx := testkeeper.ComplianceKeeper(t)
+
+			if tc.expPanic {
+				require.Panics(t,
+					func() {
+						compliance.InitGenesis(ctx, *k, *tc.genState)
+					},
+				)
+				return
+			}
+			compliance.InitGenesis(ctx, *k, *tc.genState)
+		})
+	}
+}
+
+func TestGenesis_Success(t *testing.T) {
+	testCases := []struct {
+		name     string
+		genState *types.GenesisState
+		expPanic bool
+	}{
+		{
+			name: "issuers",
+			genState: &types.GenesisState{
+				Issuers: []*types.IssuerGenesisAccount{
+					{
+						Address: "cosmos1q9y7yywh0npj2qvgey7geluuhu6j8yyd3gxf2ayk",
+						Details: &types.IssuerDetails{
+							Name: "test issuer",
+						},
+					},
+					{
+						Address: "cosmos1qyzs3crrpxjv2x6j24lc0fykvtj7q2gvcsr8s3nt",
+						Details: &types.IssuerDetails{
+							Name:        "test issuer2",
+							Description: "test description2",
+						},
+					},
+					{
+						Address: "cosmos1qgqhhu4rx9yvvdcn7e572njqyhk58swnk2aqgepj2r",
+						Details: &types.IssuerDetails{
+							Name: "test issuer3",
+							Logo: "test logo3",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "addresses",
+			genState: &types.GenesisState{
+				AddressDetails: []*types.GenesisAddressDetails{
+					{
+						Address: "cosmos1q9al9ge3frrrwylkd8j5usp9a4pur5ajhgjgry7x",
+						Details: &types.AddressDetails{
+							IsVerified: true,
+							IsRevoked:  false,
+							Verifications: []*types.Verification{{
+								Type:           types.VerificationType_VT_KYC,
+								VerificationId: nil,
+								IssuerAddress:  "0x64e739a7d5f9d9e53c7D28be3693Cc0c951d5dC0",
+							}},
+						},
+					},
+					{
+						Address: "cosmos1qydee7scj8wvd5vemkqtfr6gy7794ul9egn69yfy",
+						Details: &types.AddressDetails{
+							IsVerified:    true,
+							IsRevoked:     false,
+							Verifications: nil,
+						},
+					},
+					{
+						Address: "cosmos1lytentq4sp4hlrswlwxllppnj5gmhkxvpep445",
+						Details: &types.AddressDetails{
+							IsVerified: false,
+							IsRevoked:  false,
+							Verifications: []*types.Verification{{
+								Type:           types.VerificationType_VT_KYC,
+								VerificationId: nil,
+								IssuerAddress:  "0x3826539Cbd8d68DCF119e80B994557B4278CeC9f",
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "verifications",
+			genState: &types.GenesisState{
+				VerificationDetails: []*types.GenesisVerificationDetails{
+					{
+						Id: hexutils.HexToBytes("0273FBBAFFC58F732199B20833643248C213C5DBA8F4A05DF505713FD36B8CE2"),
+						Details: &types.VerificationDetails{
+							IssuerAddress:       "cosmos1qtu30xdvzkqxkluwpmacmluyxw23rw7ces8qtusn",
+							OriginChain:         "test chain",
+							IssuanceTimestamp:   1712018692,
+							ExpirationTimestamp: 1715018692,
+							OriginalData:        hexutils.HexToBytes("B639DF194671CDE06EFAA368A404F72E3306DF0359117AC7E78EC2BE04B7629D"),
+						},
+					},
+					{
+						Id: hexutils.HexToBytes("1075ee73240c62b820651c22f22f9371dccde1963dec74afffa493902439def2"),
+						Details: &types.VerificationDetails{
+							IssuerAddress:       "cosmos1qgq3h886rzgae3k3n8wcpdy0fqnmckhnuh9q20czzp",
+							OriginChain:         "test chain",
+							IssuanceTimestamp:   1712022843,
+							ExpirationTimestamp: 1712052843,
+							OriginalData:        hexutils.HexToBytes("0ce39a77d630007ff1b8289d878ec30822a7ee6bfdd1b2d6329edab93d2db2da"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			k, ctx := testkeeper.ComplianceKeeper(t)
+
+			if tc.expPanic {
+				require.Panics(t,
+					func() {
+						compliance.InitGenesis(ctx, *k, *tc.genState)
+					},
+				)
+				return
+			}
+			compliance.InitGenesis(ctx, *k, *tc.genState)
+
+			// Check if issuers were already initialized
+			for _, issuerData := range tc.genState.Issuers {
+				address, err := sdk.AccAddressFromBech32(issuerData.Address)
+				require.NoError(t, err)
+				i, err := k.GetIssuerDetails(ctx, address)
+				require.NoError(t, err)
+				require.NotNil(t, i)
+				require.Equal(t, issuerData.Details, i)
+			}
+
+			// Check if addresses were already initialized
+			for _, addressData := range tc.genState.AddressDetails {
+				address, err := sdk.AccAddressFromBech32(addressData.Address)
+				require.NoError(t, err)
+				i, err := k.GetAddressDetails(ctx, address)
+				require.NoError(t, err)
+				require.NotNil(t, i)
+				require.Equal(t, addressData.Details, i)
+			}
+
+			// Check if verification data was already initialized
+			for _, verificationData := range tc.genState.VerificationDetails {
+				i, err := k.GetVerificationDetails(ctx, verificationData.Id)
+				require.NoError(t, err)
+				require.NotNil(t, i)
+				require.Equal(t, verificationData.Details, i)
+			}
+
+			got := compliance.ExportGenesis(ctx, *k)
+			require.NotNil(t, got)
+
+			require.Equal(t, tc.genState.Params, got.Params)
+			// Sort by issuer address to check if two issuers are same
+			sort.Slice(tc.genState.Issuers, func(i, j int) bool { return tc.genState.Issuers[i].Address < tc.genState.Issuers[j].Address })
+			sort.Slice(got.Issuers, func(i, j int) bool { return got.Issuers[i].Address < got.Issuers[j].Address })
+			require.Equal(t, tc.genState.Issuers, got.Issuers)
+			// Sort by address to check if two address details are same
+			sort.Slice(tc.genState.AddressDetails, func(i, j int) bool {
+				return tc.genState.AddressDetails[i].Address < tc.genState.AddressDetails[j].Address
+			})
+			sort.Slice(got.AddressDetails, func(i, j int) bool { return got.AddressDetails[i].Address < got.AddressDetails[j].Address })
+			require.Equal(t, tc.genState.AddressDetails, got.AddressDetails)
+			// Sort by id to check if two verification details are same
+			sort.Slice(tc.genState.VerificationDetails, func(i, j int) bool {
+				return hexutils.BytesToHex(tc.genState.VerificationDetails[i].Id) < hexutils.BytesToHex(tc.genState.VerificationDetails[j].Id)
+			})
+			sort.Slice(got.VerificationDetails, func(i, j int) bool {
+				return hexutils.BytesToHex(got.VerificationDetails[i].Id) < hexutils.BytesToHex(got.VerificationDetails[j].Id)
+			})
+			require.Equal(t, tc.genState.VerificationDetails, got.VerificationDetails)
+		})
+	}
+}

--- a/x/compliance/genesis_test.go
+++ b/x/compliance/genesis_test.go
@@ -146,7 +146,8 @@ func TestInitGenesis_Validation(t *testing.T) {
 			expPanic: true,
 		},
 		{
-			name: "not found verification data for verified account", // there's no verification data with verification_id
+			// There's no verification data with verification_id
+			name: "not found verification data for verified account",
 			genState: &types.GenesisState{
 				Issuers: []*types.IssuerGenesisAccount{
 					{

--- a/x/compliance/genesis_test.go
+++ b/x/compliance/genesis_test.go
@@ -185,7 +185,7 @@ func TestInitGenesis_Validation(t *testing.T) {
 					},
 				},
 			},
-			expPanic: true,
+			expPanic: false,
 		},
 	}
 

--- a/x/compliance/genesis_test.go
+++ b/x/compliance/genesis_test.go
@@ -205,16 +205,29 @@ func TestInitGenesis_Validation(t *testing.T) {
 	}
 }
 
+func TestGenesis_Default(t *testing.T) {
+	// Initialize test keeper and context
+	k, ctx := testkeeper.ComplianceKeeper(t)
+
+	// Generate a sample genesis state
+	defaultGenesis := types.DefaultGenesis()
+
+	// Import genesis state
+	compliance.InitGenesis(ctx, *k, *defaultGenesis)
+
+	// Export genesis state
+	exportedGenesis := compliance.ExportGenesis(ctx, *k)
+
+	// Ensure exported genesis state matches the sample genesis state
+	require.Equal(t, defaultGenesis.Params, exportedGenesis.Params)
+}
+
 func TestGenesis_Success(t *testing.T) {
 	testCases := []struct {
 		name     string
 		genState *types.GenesisState
 		expPanic bool
 	}{
-		{
-			name:     "default",
-			genState: types.DefaultGenesis(),
-		},
 		{
 			name: "valid issuers, verifications and addresses",
 			genState: &types.GenesisState{
@@ -306,8 +319,11 @@ func TestGenesis_Success(t *testing.T) {
 					},
 				)
 				return
+			} else {
+				require.NotPanics(t, func() {
+					compliance.InitGenesis(ctx, *k, *tc.genState)
+				})
 			}
-			compliance.InitGenesis(ctx, *k, *tc.genState)
 
 			// Check if issuers were already initialized
 			for _, issuerData := range tc.genState.Issuers {

--- a/x/compliance/genesis_test.go
+++ b/x/compliance/genesis_test.go
@@ -13,6 +13,11 @@ import (
 	"swisstronik/x/compliance/types"
 )
 
+func init() {
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount("swtr", "swtrpub")
+}
+
 func TestInitGenesis_Validation(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -32,7 +37,7 @@ func TestInitGenesis_Validation(t *testing.T) {
 			name: "invalid issuers with no operators",
 			genState: &types.GenesisState{
 				Issuers: []*types.IssuerGenesisAccount{
-					{Address: "cosmos1qtu30xdvzkqxkluwpmacmluyxw23rw7ces8qtusn"},
+					{Address: "swtr1tpvqt6zfl9yef58gl7jcdpkw88thgrkf38d5zx"},
 				},
 			},
 			expPanic: true,
@@ -58,7 +63,7 @@ func TestInitGenesis_Validation(t *testing.T) {
 					{
 						Id: hexutils.HexToBytes("0273FBBAFFC58F732199B20833643248C213C5DBA8F4A05DF505713FD36B8CE2"),
 						Details: &types.VerificationDetails{
-							IssuerAddress:       "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+							IssuerAddress:       "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							OriginChain:         "test chain",
 							IssuanceTimestamp:   1715018692,
 							ExpirationTimestamp: 1712018692,
@@ -76,7 +81,7 @@ func TestInitGenesis_Validation(t *testing.T) {
 					{
 						Id: hexutils.HexToBytes("0273FBBAFFC58F732199B20833643248C213C5DBA8F4A05DF505713FD36B8CE2"),
 						Details: &types.VerificationDetails{
-							IssuerAddress:       "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+							IssuerAddress:       "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							OriginChain:         "test chain",
 							IssuanceTimestamp:   1712018692,
 							ExpirationTimestamp: 1715018692,
@@ -101,14 +106,14 @@ func TestInitGenesis_Validation(t *testing.T) {
 			genState: &types.GenesisState{
 				AddressDetails: []*types.GenesisAddressDetails{
 					{
-						Address: "cosmos1q9al9ge3frrrwylkd8j5usp9a4pur5ajhgjgry7x",
+						Address: "swtr1996rrzmj36jjd6hmfenluhxs664pdg3aewe3le",
 						Details: &types.AddressDetails{
 							IsVerified: true,
 							IsRevoked:  false,
 							Verifications: []*types.Verification{{
 								Type:           types.VerificationType_VT_KYC,
 								VerificationId: nil,
-								IssuerAddress:  "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+								IssuerAddress:  "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							}},
 						},
 					},
@@ -121,7 +126,7 @@ func TestInitGenesis_Validation(t *testing.T) {
 			genState: &types.GenesisState{
 				Issuers: []*types.IssuerGenesisAccount{
 					{
-						Address: "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+						Address: "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 						Details: &types.IssuerDetails{
 							Name:     "test issuer",
 							Operator: "test operator",
@@ -130,14 +135,14 @@ func TestInitGenesis_Validation(t *testing.T) {
 				},
 				AddressDetails: []*types.GenesisAddressDetails{
 					{
-						Address: "cosmos1q9al9ge3frrrwylkd8j5usp9a4pur5ajhgjgry7x",
+						Address: "swtr1996rrzmj36jjd6hmfenluhxs664pdg3aewe3le",
 						Details: &types.AddressDetails{
 							IsVerified: true,
 							IsRevoked:  false,
 							Verifications: []*types.Verification{{
 								Type:           types.VerificationType_VT_KYC,
 								VerificationId: nil,
-								IssuerAddress:  "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+								IssuerAddress:  "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							}},
 						},
 					},
@@ -151,7 +156,7 @@ func TestInitGenesis_Validation(t *testing.T) {
 			genState: &types.GenesisState{
 				Issuers: []*types.IssuerGenesisAccount{
 					{
-						Address: "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+						Address: "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 						Details: &types.IssuerDetails{
 							Name:     "test issuer",
 							Operator: "test operator",
@@ -160,14 +165,14 @@ func TestInitGenesis_Validation(t *testing.T) {
 				},
 				AddressDetails: []*types.GenesisAddressDetails{
 					{
-						Address: "cosmos1q9al9ge3frrrwylkd8j5usp9a4pur5ajhgjgry7x",
+						Address: "swtr1996rrzmj36jjd6hmfenluhxs664pdg3aewe3le",
 						Details: &types.AddressDetails{
 							IsVerified: true,
 							IsRevoked:  false,
 							Verifications: []*types.Verification{{
 								Type:           types.VerificationType_VT_KYC,
 								VerificationId: hexutils.HexToBytes("1075ee73240c62b820651c22f22f9371dccde1963dec74afffa493902439def2"),
-								IssuerAddress:  "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+								IssuerAddress:  "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							}},
 						},
 					},
@@ -176,7 +181,7 @@ func TestInitGenesis_Validation(t *testing.T) {
 					{
 						Id: hexutils.HexToBytes("0273FBBAFFC58F732199B20833643248C213C5DBA8F4A05DF505713FD36B8CE2"),
 						Details: &types.VerificationDetails{
-							IssuerAddress:       "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+							IssuerAddress:       "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							OriginChain:         "test chain",
 							IssuanceTimestamp:   1712018692,
 							ExpirationTimestamp: 1715018692,
@@ -234,14 +239,14 @@ func TestGenesis_Success(t *testing.T) {
 			genState: &types.GenesisState{
 				Issuers: []*types.IssuerGenesisAccount{
 					{
-						Address: "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+						Address: "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 						Details: &types.IssuerDetails{
 							Name:     "test issuer",
 							Operator: "test operator",
 						},
 					},
 					{
-						Address: "cosmos1qyzs3crrpxjv2x6j24lc0fykvtj7q2gvcsr8s3nt",
+						Address: "swtr13wl63dpe3xdhzvphp32cm9cv2vs9nvhkpaspwu",
 						Details: &types.IssuerDetails{
 							Name:        "test issuer2",
 							Description: "test description2",
@@ -251,7 +256,7 @@ func TestGenesis_Success(t *testing.T) {
 				},
 				AddressDetails: []*types.GenesisAddressDetails{
 					{
-						Address: "cosmos1qydee7scj8wvd5vemkqtfr6gy7794ul9egn69yfy",
+						Address: "swtr13yc35xh4r8ap7y440sex4nzxggxdgv7ly0cchg",
 						Details: &types.AddressDetails{
 							IsVerified:    true,
 							IsRevoked:     false,
@@ -259,26 +264,26 @@ func TestGenesis_Success(t *testing.T) {
 						},
 					},
 					{
-						Address: "cosmos1q9al9ge3frrrwylkd8j5usp9a4pur5ajhgjgry7x",
+						Address: "swtr1996rrzmj36jjd6hmfenluhxs664pdg3aewe3le",
 						Details: &types.AddressDetails{
 							IsVerified: true,
 							IsRevoked:  false,
 							Verifications: []*types.Verification{{
 								Type:           types.VerificationType_VT_KYC,
 								VerificationId: hexutils.HexToBytes("1075ee73240c62b820651c22f22f9371dccde1963dec74afffa493902439def2"),
-								IssuerAddress:  "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+								IssuerAddress:  "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							}},
 						},
 					},
 					{
-						Address: "cosmos1lytentq4sp4hlrswlwxllppnj5gmhkxvpep445",
+						Address: "swtr1flhu6pdk2ydrjqryn9utq7v5mxsr8ka67fmjj6",
 						Details: &types.AddressDetails{
 							IsVerified: false,
 							IsRevoked:  false,
 							Verifications: []*types.Verification{{
 								Type:           types.VerificationType_VT_KYC,
 								VerificationId: hexutils.HexToBytes("0273FBBAFFC58F732199B20833643248C213C5DBA8F4A05DF505713FD36B8CE2"),
-								IssuerAddress:  "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+								IssuerAddress:  "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							}},
 						},
 					},
@@ -287,7 +292,7 @@ func TestGenesis_Success(t *testing.T) {
 					{
 						Id: hexutils.HexToBytes("0273FBBAFFC58F732199B20833643248C213C5DBA8F4A05DF505713FD36B8CE2"),
 						Details: &types.VerificationDetails{
-							IssuerAddress:       "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+							IssuerAddress:       "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							OriginChain:         "test chain",
 							IssuanceTimestamp:   1712018692,
 							ExpirationTimestamp: 1715018692,
@@ -297,7 +302,7 @@ func TestGenesis_Success(t *testing.T) {
 					{
 						Id: hexutils.HexToBytes("1075ee73240c62b820651c22f22f9371dccde1963dec74afffa493902439def2"),
 						Details: &types.VerificationDetails{
-							IssuerAddress:       "cosmos1qyqs2z8qvvy6f3gm2f2hlpayje3wtcpfpnzqjn6pp6",
+							IssuerAddress:       "swtr199wynlfwhj6ytkvujjf6mel5z7fl0mwzqck8l6",
 							OriginChain:         "test chain",
 							IssuanceTimestamp:   1712022843,
 							ExpirationTimestamp: 1712052843,

--- a/x/compliance/keeper/keeper.go
+++ b/x/compliance/keeper/keeper.go
@@ -115,12 +115,6 @@ func (k Keeper) GetAddressDetails(ctx sdk.Context, address sdk.Address) (*types.
 			newVerifications = append(newVerifications, verification)
 		}
 	}
-	if len(newVerifications) != len(addressDetails.Verifications) {
-		// If found invalid verification, update address details with latest
-		if err := k.SetAddressDetails(ctx, address, &addressDetails); err != nil {
-			return nil, err
-		}
-	}
 	addressDetails.Verifications = newVerifications
 
 	return &addressDetails, nil

--- a/x/compliance/keeper/keeper.go
+++ b/x/compliance/keeper/keeper.go
@@ -310,7 +310,8 @@ func (k Keeper) IterateVerificationDetails(ctx sdk.Context, callback func(id []b
 
 	for ; latestVersionIterator.Valid(); latestVersionIterator.Next() {
 		key := latestVersionIterator.Key()
-		if !callback(key) {
+		id := types.VerificationIdFromKey(key)
+		if !callback(id) {
 			break
 		}
 	}
@@ -322,7 +323,7 @@ func (k Keeper) IterateAddressDetails(ctx sdk.Context, callback func(address sdk
 
 	for ; latestVersionIterator.Valid(); latestVersionIterator.Next() {
 		key := latestVersionIterator.Key()
-		address := sdk.AccAddress(key)
+		address := types.AccAddressFromKey(key)
 		if !callback(address) {
 			break
 		}
@@ -335,7 +336,7 @@ func (k Keeper) IterateIssuerDetails(ctx sdk.Context, callback func(address sdk.
 
 	for ; latestVersionIterator.Valid(); latestVersionIterator.Next() {
 		key := latestVersionIterator.Key()
-		address := sdk.AccAddress(key)
+		address := types.AccAddressFromKey(key)
 		if !callback(address) {
 			break
 		}

--- a/x/compliance/keeper/keeper_test.go
+++ b/x/compliance/keeper/keeper_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	"context"
-	"swisstronik/tests"
 	"testing"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"swisstronik/app"
+	"swisstronik/tests"
 	"swisstronik/utils"
 	"swisstronik/x/compliance/keeper"
 	"swisstronik/x/compliance/types"
@@ -27,6 +27,11 @@ type KeeperTestSuite struct {
 	goCtx  context.Context
 	keeper keeper.Keeper
 	app    *app.App
+}
+
+func init() {
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount("swtr", "swtrpub")
 }
 
 func TestKeeperTestSuite(t *testing.T) {

--- a/x/compliance/keeper/keeper_test.go
+++ b/x/compliance/keeper/keeper_test.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/status-im/keycard-go/hexutils"
 	"github.com/stretchr/testify/suite"
 
 	"swisstronik/app"
@@ -66,6 +67,124 @@ func (suite *KeeperTestSuite) TestNonExistingIssuer() {
 	address := sdk.AccAddress(from.Bytes())
 	i, err := suite.keeper.GetIssuerDetails(suite.ctx, address)
 	suite.Require().Equal("", i.Name)
+	// todo, operator is empty
+	suite.Require().NoError(err)
+}
+
+func (suite *KeeperTestSuite) TestSuspendedIssuer() {
+	details := &types.IssuerDetails{Name: "testIssuer"}
+	from, _ := tests.RandomEthAddressWithPrivateKey()
+	issuer := sdk.AccAddress(from.Bytes())
+	err := suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+	suite.Require().NoError(err)
+
+	// Revoke verification status for test issuer
+	err = suite.keeper.SetAddressVerificationStatus(suite.ctx, issuer, false)
+	suite.Require().NoError(err)
+
+	from, _ = tests.RandomEthAddressWithPrivateKey()
+	signer := sdk.AccAddress(from.Bytes())
+
+	// Should not allow to add verification details verified by suspended issuer
+	// Even if issuer was suspended, verification data should exist
+	err = suite.keeper.AddVerificationDetails(
+		suite.ctx,
+		signer,
+		types.VerificationType_VT_KYC,
+		&types.VerificationDetails{
+			IssuerAddress:       issuer.String(),
+			OriginChain:         "test chain",
+			IssuanceTimestamp:   1712018692,
+			ExpirationTimestamp: 1715018692,
+			OriginalData:        hexutils.HexToBytes("B639DF194671CDE06EFAA368A404F72E3306DF0359117AC7E78EC2BE04B7629D"),
+		},
+	)
+	suite.Require().Error(err)
+}
+
+func (suite *KeeperTestSuite) TestRemovedIssuer() {
+	issuerDetails := &types.IssuerDetails{Name: "testIssuer"}
+	from, _ := tests.RandomEthAddressWithPrivateKey()
+	issuer := sdk.AccAddress(from.Bytes())
+	err := suite.keeper.SetIssuerDetails(suite.ctx, issuer, issuerDetails)
+	suite.Require().NoError(err)
+
+	err = suite.keeper.SetAddressVerificationStatus(suite.ctx, issuer, true)
+	suite.Require().NoError(err)
+
+	from, _ = tests.RandomEthAddressWithPrivateKey()
+	signer := sdk.AccAddress(from.Bytes())
+
+	// Add dummy verification details and address details with verifications
+	err = suite.keeper.SetAddressDetails(
+		suite.ctx,
+		issuer,
+		&types.AddressDetails{
+			IsVerified: true,
+			IsRevoked:  false,
+		})
+	err = suite.keeper.AddVerificationDetails(
+		suite.ctx,
+		signer,
+		types.VerificationType_VT_KYC,
+		&types.VerificationDetails{
+			IssuerAddress:       issuer.String(),
+			OriginChain:         "test chain",
+			IssuanceTimestamp:   1712018692,
+			ExpirationTimestamp: 1715018692,
+			OriginalData:        hexutils.HexToBytes("B639DF194671CDE06EFAA368A404F72E3306DF0359117AC7E78EC2BE04B7629D"),
+		},
+	)
+	suite.Require().NoError(err)
+
+	suite.keeper.RemoveIssuer(suite.ctx, issuer)
+	i, err := suite.keeper.GetIssuerDetails(suite.ctx, issuer)
+	suite.Require().Equal(i, &types.IssuerDetails{})
+	suite.Require().NoError(err)
+
+	// AddressDetails for removed issuer should not exist
+	addressDetails, err := suite.keeper.GetAddressDetails(suite.ctx, issuer)
+	suite.Require().Equal(addressDetails, &types.AddressDetails{})
+	suite.Require().NoError(err)
+
+	// If issuer was removed, all the verification details which were verified by removed issuer
+	// should be removed every time when call `GetVerificationDetails` or `GetAddressDetails`.
+	verificationDetails, err := suite.keeper.GetVerificationsOfType(
+		suite.ctx,
+		signer,
+		types.VerificationType_VT_KYC,
+		issuer,
+	)
+	suite.Require().NoError(err)
+	suite.Require().Equal(0, len(verificationDetails))
+}
+
+func (suite *KeeperTestSuite) TestAddVerificationDetails() {
+	details := &types.IssuerDetails{Name: "testIssuer"}
+	from, _ := tests.RandomEthAddressWithPrivateKey()
+	issuer := sdk.AccAddress(from.Bytes())
+	err := suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+	suite.Require().NoError(err)
+
+	err = suite.keeper.SetAddressVerificationStatus(suite.ctx, issuer, true)
+	suite.Require().NoError(err)
+
+	from, _ = tests.RandomEthAddressWithPrivateKey()
+	signer := sdk.AccAddress(from.Bytes())
+
+	// Allow to add verification details verified by active issuer
+	err = suite.keeper.AddVerificationDetails(
+		suite.ctx,
+		signer,
+		types.VerificationType_VT_KYC,
+		&types.VerificationDetails{
+			IssuerAddress:       issuer.String(),
+			OriginChain:         "test chain",
+			IssuanceTimestamp:   1712018692,
+			ExpirationTimestamp: 1715018692,
+			OriginalData:        hexutils.HexToBytes("B639DF194671CDE06EFAA368A404F72E3306DF0359117AC7E78EC2BE04B7629D"),
+		},
+	)
 	suite.Require().NoError(err)
 }
 
@@ -77,7 +196,7 @@ func (suite *KeeperTestSuite) TestAddressDetailsCRUD() {
 		Verifications: []*types.Verification{{
 			Type:           types.VerificationType_VT_KYC,
 			VerificationId: nil,
-			IssuerAddress:  from.String(),
+			IssuerAddress:  address.String(),
 		}}}
 	err := suite.keeper.SetAddressDetails(suite.ctx, address, details)
 	suite.Require().NoError(err)
@@ -90,7 +209,7 @@ func (suite *KeeperTestSuite) TestAddressVerified() {
 	from, _ := tests.RandomEthAddressWithPrivateKey()
 	address := sdk.AccAddress(from.Bytes())
 	details := &types.AddressDetails{IsVerified: true,
-		IsRevoked: false,
+		IsRevoked:     false,
 		Verifications: make([]*types.Verification, 0)}
 	err := suite.keeper.SetAddressDetails(suite.ctx, address, details)
 	suite.Require().NoError(err)
@@ -99,7 +218,7 @@ func (suite *KeeperTestSuite) TestAddressVerified() {
 	from2, _ := tests.RandomEthAddressWithPrivateKey()
 	address2 := sdk.AccAddress(from2.Bytes())
 	details2 := &types.AddressDetails{IsVerified: false,
-		IsRevoked: false,
+		IsRevoked:     false,
 		Verifications: make([]*types.Verification, 0)}
 	err = suite.keeper.SetAddressDetails(suite.ctx, address2, details2)
 	suite.Require().NoError(err)
@@ -107,34 +226,33 @@ func (suite *KeeperTestSuite) TestAddressVerified() {
 	suite.Require().Equal(false, i)
 }
 
-
 func (suite *KeeperTestSuite) TestAddressDetailsSetVerificationStatus() {
 	from, _ := tests.RandomEthAddressWithPrivateKey()
 	address := sdk.AccAddress(from.Bytes())
 	details := &types.AddressDetails{
 		IsVerified: false,
-		IsRevoked: false,
+		IsRevoked:  false,
 		Verifications: []*types.Verification{{
 			Type:           types.VerificationType_VT_KYC,
 			VerificationId: nil,
-			IssuerAddress:  from.String(),
+			IssuerAddress:  address.String(),
 		}}}
 	err := suite.keeper.SetAddressDetails(suite.ctx, address, details)
 	suite.Require().NoError(err)
 	// set to true
-	err = suite.keeper.SetAddressVerificationStatus(suite.ctx,address, true)
+	err = suite.keeper.SetAddressVerificationStatus(suite.ctx, address, true)
 	suite.Require().NoError(err)
 	i, err := suite.keeper.GetAddressDetails(suite.ctx, address)
 	suite.Require().Equal(true, i.IsVerified)
 	suite.Require().NoError(err)
 	// set to false
-	err = suite.keeper.SetAddressVerificationStatus(suite.ctx,address, false)
+	err = suite.keeper.SetAddressVerificationStatus(suite.ctx, address, false)
 	suite.Require().NoError(err)
 	i, err = suite.keeper.GetAddressDetails(suite.ctx, address)
 	suite.Require().Equal(false, i.IsVerified)
 	suite.Require().NoError(err)
 	// NOOP
-	err = suite.keeper.SetAddressVerificationStatus(suite.ctx,address, false)
+	err = suite.keeper.SetAddressVerificationStatus(suite.ctx, address, false)
 	suite.Require().NoError(err)
 	i, err = suite.keeper.GetAddressDetails(suite.ctx, address)
 	suite.Require().Equal(false, i.IsVerified)

--- a/x/compliance/keeper/msg_server.go
+++ b/x/compliance/keeper/msg_server.go
@@ -5,7 +5,7 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	
+
 	"swisstronik/x/compliance/types"
 )
 
@@ -54,6 +54,11 @@ func (k msgServer) HandleSetIssuerDetails(goCtx context.Context, msg *types.MsgS
 	}
 
 	if err := k.SetIssuerDetails(ctx, issuerAddress, msg.Details); err != nil {
+		return nil, err
+	}
+
+	// If issuer is freshly created, verification status should be false
+	if err = k.SetAddressVerificationStatus(ctx, issuerAddress, false); err != nil {
 		return nil, err
 	}
 

--- a/x/compliance/keeper/msg_server.go
+++ b/x/compliance/keeper/msg_server.go
@@ -2,8 +2,10 @@ package keeper
 
 import (
 	"context"
+
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	
 	"swisstronik/x/compliance/types"
 )
 

--- a/x/compliance/keeper/msg_server_test.go
+++ b/x/compliance/keeper/msg_server_test.go
@@ -133,6 +133,11 @@ func (suite *KeeperTestSuite) TestSetIssuerDetails() {
 				suite.Require().Equal("issuer logo", details.Logo)
 				suite.Require().Equal("issuer legal entity", details.LegalEntity)
 				suite.Require().Equal(operator.String(), details.Operator)
+
+				// Check if issuer's verification status is false
+				verified, error := suite.keeper.IsAddressVerified(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().False(verified)
 			},
 		},
 		{

--- a/x/compliance/keeper/msg_server_test.go
+++ b/x/compliance/keeper/msg_server_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/status-im/keycard-go/hexutils"
+
 	"swisstronik/tests"
 	"swisstronik/x/compliance/keeper"
 	"swisstronik/x/compliance/types"
@@ -432,7 +433,7 @@ func (suite *KeeperTestSuite) TestUpdateIssuerDetails() {
 				signer = sdk.AccAddress(from.Bytes())
 
 				// Add address details with verification details
-				_ = suite.keeper.AddVerificationDetails(
+				_, _ = suite.keeper.AddVerificationDetails(
 					suite.ctx,
 					signer,
 					types.VerificationType_VT_KYC,
@@ -628,7 +629,7 @@ func (suite *KeeperTestSuite) TestRemoveIssuer() {
 				signer = sdk.AccAddress(from.Bytes())
 
 				// Add address details with verification details
-				_ = suite.keeper.AddVerificationDetails(
+				_, _ = suite.keeper.AddVerificationDetails(
 					suite.ctx,
 					signer,
 					types.VerificationType_VT_KYC,

--- a/x/compliance/keeper/msg_server_test.go
+++ b/x/compliance/keeper/msg_server_test.go
@@ -1,0 +1,414 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"swisstronik/tests"
+	"swisstronik/x/compliance/keeper"
+	"swisstronik/x/compliance/types"
+)
+
+func (suite *KeeperTestSuite) TestSetIssuerDetails() {
+	var (
+		operator sdk.AccAddress
+		issuer   sdk.AccAddress
+		signer   sdk.AccAddress
+	)
+	testCases := []struct {
+		name     string
+		malleate func() *types.MsgSetIssuerDetails
+		expected func(resp *types.MsgSetIssuerDetailsResponse, error error)
+	}{
+		{
+			name: "invalid fields",
+			malleate: func() *types.MsgSetIssuerDetails {
+				msg := types.NewSetIssuerDetailsMsg("operator address", "issuer address", "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(resp *types.MsgSetIssuerDetailsResponse, error error) {
+				suite.Require().Error(error)
+			},
+		},
+		{
+			name: "mismatch operator and signer",
+			malleate: func() *types.MsgSetIssuerDetails {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				signer = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewSetIssuerDetailsMsg(operator.String(), "issuer address", "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				msg.Signer = signer.String()
+				return &msg
+			},
+			expected: func(resp *types.MsgSetIssuerDetailsResponse, error error) {
+				suite.Require().Error(error)
+			},
+		},
+		{
+			name: "invalid issuer",
+			malleate: func() *types.MsgSetIssuerDetails {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewSetIssuerDetailsMsg(operator.String(), "issuer address", "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(resp *types.MsgSetIssuerDetailsResponse, error error) {
+				suite.Require().Error(error)
+			},
+		},
+		{
+			name: "success",
+			malleate: func() *types.MsgSetIssuerDetails {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewSetIssuerDetailsMsg(operator.String(), issuer.String(), "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(resp *types.MsgSetIssuerDetailsResponse, error error) {
+				suite.Require().NoError(error)
+
+				// Issuer should exist
+				issuerExists, err := suite.keeper.IssuerExists(suite.ctx, issuer)
+				suite.Require().True(issuerExists)
+				suite.Require().NoError(err)
+
+				// Should be revoked verification if issuer address was verified
+				addressDetails, err := suite.keeper.GetAddressDetails(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().Equal(false, addressDetails.IsVerified)
+
+				// Check if issuer details are stored correctly
+				details, err := suite.keeper.GetIssuerDetails(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().Equal("issuer name", details.Name)
+				suite.Require().Equal("issuer description", details.Description)
+				suite.Require().Equal("issuer url", details.Url)
+				suite.Require().Equal("issuer logo", details.Logo)
+				suite.Require().Equal("issuer legal entity", details.LegalEntity)
+				suite.Require().Equal(operator.String(), details.Operator)
+			},
+		},
+		{
+			name: "existing issuer",
+			malleate: func() *types.MsgSetIssuerDetails {
+				details := &types.IssuerDetails{Name: "test issuer", Operator: "operator"}
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+				msg := types.NewSetIssuerDetailsMsg(operator.String(), issuer.String(), "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(resp *types.MsgSetIssuerDetailsResponse, error error) {
+				suite.Require().Error(error)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			msgServer := keeper.NewMsgServerImpl(suite.keeper)
+			msg := tc.malleate()
+			resp, err := msgServer.HandleSetIssuerDetails(sdk.WrapSDKContext(suite.ctx), msg)
+			tc.expected(resp, err)
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestUpdateIssuerDetails() {
+	var (
+		issuer      sdk.AccAddress
+		operator    sdk.AccAddress
+		newOperator sdk.AccAddress
+		signer      sdk.AccAddress
+	)
+
+	testCases := []struct {
+		name     string
+		malleate func() *types.MsgUpdateIssuerDetails
+		expected func(response *types.MsgUpdateIssuerDetailsResponse, error error)
+	}{
+		{
+			name: "invalid fields",
+			malleate: func() *types.MsgUpdateIssuerDetails {
+				msg := types.NewUpdateIssuerDetailsMsg("exiting operator", "new operator", "issuer address", "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(_ *types.MsgUpdateIssuerDetailsResponse, err error) {
+				suite.Require().Error(err)
+			},
+		},
+		{
+			name: "issuer not exist",
+			malleate: func() *types.MsgUpdateIssuerDetails {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewUpdateIssuerDetailsMsg(operator.String(), operator.String(), issuer.String(), "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(_ *types.MsgUpdateIssuerDetailsResponse, err error) {
+				suite.Require().Error(err)
+			},
+		},
+		{
+			name: "invalid issuer exist",
+			malleate: func() *types.MsgUpdateIssuerDetails {
+				// Invalid issuer details were added in the store
+				details := &types.IssuerDetails{Name: "test issuer"} // missing operator
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewUpdateIssuerDetailsMsg(operator.String(), operator.String(), issuer.String(), "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(_ *types.MsgUpdateIssuerDetailsResponse, err error) {
+				suite.Require().Error(err)
+			},
+		},
+		{
+			name: "mismatch operator and signer",
+			malleate: func() *types.MsgUpdateIssuerDetails {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+				details := &types.IssuerDetails{Name: "test issuer", Operator: operator.String()}
+				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				// New signer, different from previous operator
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				signer = sdk.AccAddress(from.Bytes())
+
+				// existing operator (should pass operator, but passing signer) and new operator(no change operator)
+				msg := types.NewUpdateIssuerDetailsMsg(signer.String(), operator.String(), issuer.String(), "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(_ *types.MsgUpdateIssuerDetailsResponse, err error) {
+				suite.Require().Error(err)
+			},
+		},
+		{
+			name: "success",
+			malleate: func() *types.MsgUpdateIssuerDetails {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+				details := &types.IssuerDetails{Name: "test issuer", Operator: operator.String()}
+				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				msg := types.NewUpdateIssuerDetailsMsg(operator.String(), operator.String(), issuer.String(), "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(_ *types.MsgUpdateIssuerDetailsResponse, err error) {
+				suite.Require().NoError(err)
+
+				// Issuer should exist
+				issuerExists, err := suite.keeper.IssuerExists(suite.ctx, issuer)
+				suite.Require().True(issuerExists)
+				suite.Require().NoError(err)
+
+				// Should be revoked verification if issuer address was verified
+				addressDetails, err := suite.keeper.GetAddressDetails(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().Equal(false, addressDetails.IsVerified)
+
+				// Check if issuer details are stored correctly
+				details, err := suite.keeper.GetIssuerDetails(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().Equal("issuer name", details.Name)
+				suite.Require().Equal("issuer description", details.Description)
+				suite.Require().Equal("issuer url", details.Url)
+				suite.Require().Equal("issuer logo", details.Logo)
+				suite.Require().Equal("issuer legal entity", details.LegalEntity)
+				suite.Require().Equal(operator.String(), details.Operator)
+			},
+		},
+		{
+			name: "new operator over existing",
+			malleate: func() *types.MsgUpdateIssuerDetails {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+				details := &types.IssuerDetails{Name: "test issuer", Operator: operator.String()}
+				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				newOperator = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewUpdateIssuerDetailsMsg(operator.String(), newOperator.String(), issuer.String(), "issuer name", "issuer description", "issuer url", "issuer logo", "issuer legal entity")
+				return &msg
+			},
+			expected: func(_ *types.MsgUpdateIssuerDetailsResponse, err error) {
+				suite.Require().NoError(err)
+
+				// Issuer details should exist
+				issuerExists, err := suite.keeper.IssuerExists(suite.ctx, issuer)
+				suite.Require().True(issuerExists)
+				suite.Require().NoError(err)
+
+				// Should be revoked verification if issuer address was verified
+				addressDetails, err := suite.keeper.GetAddressDetails(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().Equal(false, addressDetails.IsVerified)
+
+				// Check if issuer details are stored correctly, especially new operator
+				details, err := suite.keeper.GetIssuerDetails(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().Equal("issuer name", details.Name)
+				suite.Require().Equal("issuer description", details.Description)
+				suite.Require().Equal("issuer url", details.Url)
+				suite.Require().Equal("issuer logo", details.Logo)
+				suite.Require().Equal("issuer legal entity", details.LegalEntity)
+				suite.Require().Equal(newOperator.String(), details.Operator)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			msgServer := keeper.NewMsgServerImpl(suite.keeper)
+			msg := tc.malleate()
+			resp, err := msgServer.HandleUpdateIssuerDetails(sdk.WrapSDKContext(suite.ctx), msg)
+			tc.expected(resp, err)
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestRemoveIssuer() {
+	var (
+		issuer   sdk.AccAddress
+		operator sdk.AccAddress
+		signer   sdk.AccAddress
+	)
+	testCases := []struct {
+		name     string
+		malleate func() *types.MsgRemoveIssuer
+		expected func(resp *types.MsgRemoveIssuerResponse, error error)
+	}{
+		{
+			name: "invalid fields",
+			malleate: func() *types.MsgRemoveIssuer {
+				msg := types.NewRemoveIssuerMsg("operator", "issuer address")
+				return &msg
+			},
+			expected: func(_ *types.MsgRemoveIssuerResponse, err error) {
+				suite.Require().Error(err)
+			},
+		},
+		{
+			name: "issuer not exist",
+			malleate: func() *types.MsgRemoveIssuer {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewRemoveIssuerMsg(operator.String(), issuer.String())
+				return &msg
+			},
+			expected: func(_ *types.MsgRemoveIssuerResponse, err error) {
+				suite.Require().Error(err)
+			},
+		},
+		{
+			name: "invalid issuer exist",
+			malleate: func() *types.MsgRemoveIssuer {
+				// Invalid issuer details were added in the store
+				details := &types.IssuerDetails{Name: "test issuer"} // missing operator
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewRemoveIssuerMsg(operator.String(), issuer.String())
+				return &msg
+			},
+			expected: func(_ *types.MsgRemoveIssuerResponse, err error) {
+				suite.Require().Error(err)
+			},
+		},
+		{
+			name: "mismatch operator and signer",
+			malleate: func() *types.MsgRemoveIssuer {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+				details := &types.IssuerDetails{Name: "test issuer", Operator: operator.String()}
+				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				// New signer, different from previous operator
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				signer = sdk.AccAddress(from.Bytes())
+
+				msg := types.NewRemoveIssuerMsg(signer.String(), issuer.String())
+				return &msg
+			},
+			expected: func(_ *types.MsgRemoveIssuerResponse, err error) {
+				suite.Require().Error(err)
+			},
+		},
+		{
+			name: "success",
+			malleate: func() *types.MsgRemoveIssuer {
+				from, _ := tests.RandomEthAddressWithPrivateKey()
+				operator = sdk.AccAddress(from.Bytes())
+
+				from, _ = tests.RandomEthAddressWithPrivateKey()
+				issuer = sdk.AccAddress(from.Bytes())
+				details := &types.IssuerDetails{Name: "test issuer", Operator: operator.String()}
+				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				msg := types.NewRemoveIssuerMsg(operator.String(), issuer.String())
+				return &msg
+			},
+			expected: func(_ *types.MsgRemoveIssuerResponse, err error) {
+				suite.Require().NoError(err)
+
+				// Issuer should not exist
+				issuerExists, err := suite.keeper.IssuerExists(suite.ctx, issuer)
+				suite.Require().False(issuerExists)
+				suite.Require().NoError(err)
+
+				// Same for issuer details
+				details, err := suite.keeper.GetIssuerDetails(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().Equal(details, &types.IssuerDetails{})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			msgServer := keeper.NewMsgServerImpl(suite.keeper)
+			msg := tc.malleate()
+			resp, err := msgServer.HandleRemoveIssuer(sdk.WrapSDKContext(suite.ctx), msg)
+			tc.expected(resp, err)
+		})
+	}
+}

--- a/x/compliance/keeper/msg_server_test.go
+++ b/x/compliance/keeper/msg_server_test.go
@@ -421,6 +421,8 @@ func (suite *KeeperTestSuite) TestUpdateIssuerDetails() {
 				details := &types.IssuerDetails{Name: "test issuer", Operator: operator.String()}
 				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
 
+				_ = suite.keeper.SetAddressVerificationStatus(suite.ctx, issuer, true)
+
 				from, _ = tests.RandomEthAddressWithPrivateKey()
 				signer = sdk.AccAddress(from.Bytes())
 
@@ -593,9 +595,14 @@ func (suite *KeeperTestSuite) TestRemoveIssuer() {
 				suite.Require().NoError(err)
 
 				// Same for issuer details
-				details, err := suite.keeper.GetIssuerDetails(suite.ctx, issuer)
+				issuerDetails, err := suite.keeper.GetIssuerDetails(suite.ctx, issuer)
 				suite.Require().NoError(err)
-				suite.Require().Equal(details, &types.IssuerDetails{})
+				suite.Require().Equal(issuerDetails, &types.IssuerDetails{})
+
+				// Address details for removed issuer should not exit
+				addressDetails, err := suite.keeper.GetAddressDetails(suite.ctx, issuer)
+				suite.Require().NoError(err)
+				suite.Require().Equal(addressDetails, &types.AddressDetails{})
 			},
 		},
 		{
@@ -609,6 +616,8 @@ func (suite *KeeperTestSuite) TestRemoveIssuer() {
 				issuer = sdk.AccAddress(from.Bytes())
 				details := &types.IssuerDetails{Name: "test issuer", Operator: operator.String()}
 				_ = suite.keeper.SetIssuerDetails(suite.ctx, issuer, details)
+
+				_ = suite.keeper.SetAddressVerificationStatus(suite.ctx, issuer, true)
 
 				from, _ = tests.RandomEthAddressWithPrivateKey()
 				signer = sdk.AccAddress(from.Bytes())

--- a/x/compliance/keeper/params_test.go
+++ b/x/compliance/keeper/params_test.go
@@ -13,6 +13,5 @@ func TestGetParams(t *testing.T) {
 	params := types.DefaultParams()
 
 	k.SetParams(ctx, params)
-
 	require.EqualValues(t, params, k.GetParams(ctx))
 }

--- a/x/compliance/keeper/query.go
+++ b/x/compliance/keeper/query.go
@@ -8,9 +8,14 @@ import (
 	"swisstronik/x/compliance/types"
 )
 
-var _ types.QueryServer = Keeper{}
+// Querier is used as Keeper will have duplicate methods if used directly, and gRPC names take precedence over keeper
+type Querier struct {
+	Keeper
+}
 
-func (k Keeper) AddressDetails(goCtx context.Context, req *types.QueryAddressDetailsRequest) (*types.QueryAddressDetailsResponse, error) {
+var _ types.QueryServer = Querier{}
+
+func (k Querier) AddressDetails(goCtx context.Context, req *types.QueryAddressDetailsRequest) (*types.QueryAddressDetailsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -29,7 +34,7 @@ func (k Keeper) AddressDetails(goCtx context.Context, req *types.QueryAddressDet
 	return &types.QueryAddressDetailsResponse{Data: details}, nil
 }
 
-func (k Keeper) IssuerDetails(goCtx context.Context, req *types.QueryIssuerDetailsRequest) (*types.QueryIssuerDetailsResponse, error) {
+func (k Querier) IssuerDetails(goCtx context.Context, req *types.QueryIssuerDetailsRequest) (*types.QueryIssuerDetailsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -48,7 +53,7 @@ func (k Keeper) IssuerDetails(goCtx context.Context, req *types.QueryIssuerDetai
 	return &types.QueryIssuerDetailsResponse{Details: issuerDetails}, nil
 }
 
-func (k Keeper) VerificationDetails(goCtx context.Context, req *types.QueryVerificationDetailsRequest) (*types.QueryVerificationDetailsResponse, error) {
+func (k Querier) VerificationDetails(goCtx context.Context, req *types.QueryVerificationDetailsRequest) (*types.QueryVerificationDetailsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}

--- a/x/compliance/keeper/query_params.go
+++ b/x/compliance/keeper/query_params.go
@@ -9,7 +9,7 @@ import (
 	"swisstronik/x/compliance/types"
 )
 
-func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (k Querier) Params(goCtx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}

--- a/x/compliance/keeper/query_params_test.go
+++ b/x/compliance/keeper/query_params_test.go
@@ -1,0 +1,21 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	testkeeper "swisstronik/testutil/keeper"
+	"swisstronik/x/compliance/keeper"
+	"swisstronik/x/compliance/types"
+	"testing"
+)
+
+func TestQueryParams(t *testing.T) {
+	k, ctx := testkeeper.ComplianceKeeper(t)
+	params := types.DefaultParams()
+
+	k.SetParams(ctx, params)
+	q := keeper.Querier{Keeper: *k}
+	resp, err := q.Params(sdk.WrapSDKContext(ctx), &types.QueryParamsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, resp.Params, params)
+}

--- a/x/compliance/keeper/query_params_test.go
+++ b/x/compliance/keeper/query_params_test.go
@@ -1,12 +1,14 @@
 package keeper_test
 
 import (
+	"testing"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+
 	testkeeper "swisstronik/testutil/keeper"
 	"swisstronik/x/compliance/keeper"
 	"swisstronik/x/compliance/types"
-	"testing"
 )
 
 func TestQueryParams(t *testing.T) {

--- a/x/compliance/keeper/query_test.go
+++ b/x/compliance/keeper/query_test.go
@@ -1,0 +1,151 @@
+package keeper_test
+
+import (
+	"context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/status-im/keycard-go/hexutils"
+	"github.com/stretchr/testify/suite"
+	"swisstronik/app"
+	"swisstronik/tests"
+	testkeeper "swisstronik/testutil/keeper"
+	"swisstronik/x/compliance/keeper"
+	"swisstronik/x/compliance/types"
+	"testing"
+)
+
+type QuerierTestSuite struct {
+	suite.Suite
+
+	ctx     sdk.Context
+	goCtx   context.Context
+	keeper  keeper.Keeper
+	querier keeper.Querier
+	app     *app.App
+
+	issuer sdk.AccAddress
+	user   sdk.AccAddress
+}
+
+func TestQuerierTestSuite(t *testing.T) {
+	s := new(QuerierTestSuite)
+	k, ctx := testkeeper.ComplianceKeeper(t)
+	s.ctx = ctx
+	s.goCtx = sdk.WrapSDKContext(ctx)
+	s.keeper = *k
+	s.querier = keeper.Querier{Keeper: s.keeper}
+
+	suite.Run(t, s)
+}
+
+func (suite *QuerierTestSuite) SetupTest() {
+	from, _ := tests.RandomEthAddressWithPrivateKey()
+	suite.issuer = sdk.AccAddress(from.Bytes())
+
+	from, _ = tests.RandomEthAddressWithPrivateKey()
+	suite.user = sdk.AccAddress(from.Bytes())
+
+	// Set issuer details
+	issuerDetails := &types.IssuerDetails{Name: "testIssuer", Operator: "testOperator"}
+	err := suite.keeper.SetIssuerDetails(suite.ctx, suite.issuer, issuerDetails)
+	suite.Require().NoError(err)
+
+	// Set verification status as true for issuer details
+	err = suite.keeper.SetAddressVerificationStatus(suite.ctx, suite.issuer, true)
+	suite.Require().NoError(err)
+
+	// Add address details
+	err = suite.keeper.SetAddressDetails(
+		suite.ctx,
+		suite.user,
+		&types.AddressDetails{
+			IsVerified: true,
+			IsRevoked:  false,
+		})
+
+	// Add verification details and address details
+	verificationId, err := suite.keeper.AddVerificationDetails(
+		suite.ctx,
+		suite.user,
+		types.VerificationType_VT_KYC,
+		&types.VerificationDetails{
+			IssuerAddress:       suite.issuer.String(),
+			OriginChain:         "test chain",
+			IssuanceTimestamp:   1712018692,
+			ExpirationTimestamp: 1715018692,
+			OriginalData:        hexutils.HexToBytes("B639DF194671CDE06EFAA368A404F72E3306DF0359117AC7E78EC2BE04B7629D"),
+		},
+	)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(verificationId)
+}
+
+func (suite *QuerierTestSuite) TestSuccess() {
+	// Query issuer details
+	issuerRequest := &types.QueryIssuerDetailsRequest{
+		IssuerAddress: suite.issuer.String(),
+	}
+	issuerDetails, err := suite.querier.IssuerDetails(suite.goCtx, issuerRequest)
+	suite.Require().NoError(err)
+	suite.Require().Equal(issuerDetails.Details.Name, "testIssuer")
+	suite.Require().Equal(issuerDetails.Details.Operator, "testOperator")
+
+	// Query address details
+	addressRequest := &types.QueryAddressDetailsRequest{
+		Address: suite.user.String(),
+	}
+	addressDetails, err := suite.querier.AddressDetails(suite.goCtx, addressRequest)
+	suite.Require().NoError(err)
+	suite.Require().Equal(addressDetails.Data.IsVerified, true)
+	suite.Require().Greater(len(addressDetails.Data.Verifications), 0)
+
+	verification := addressDetails.Data.Verifications[0]
+
+	// Query verification details
+	verificationRequest := &types.QueryVerificationDetailsRequest{
+		VerificationID: string(verification.VerificationId),
+	}
+	verificationDetails, err := suite.querier.VerificationDetails(suite.goCtx, verificationRequest)
+	suite.Require().NoError(err)
+	suite.Require().Equal(verificationDetails.Details.IssuerAddress, verification.IssuerAddress)
+}
+
+func (suite *QuerierTestSuite) TestFailed() {
+	from, _ := tests.RandomEthAddressWithPrivateKey()
+	anyUser := sdk.AccAddress(from.Bytes())
+
+	// Query invalid issuer details
+	issuerRequest := &types.QueryIssuerDetailsRequest{
+		IssuerAddress: "invalid issuer",
+	}
+	issuerDetails, err := suite.querier.IssuerDetails(suite.goCtx, issuerRequest)
+	suite.Require().Error(err) // Failed in parsing acc address
+
+	issuerRequest = &types.QueryIssuerDetailsRequest{
+		IssuerAddress: anyUser.String(),
+	}
+	issuerDetails, err = suite.querier.IssuerDetails(suite.goCtx, issuerRequest)
+	suite.Require().NoError(err)
+	suite.Require().Equal(issuerDetails.Details, &types.IssuerDetails{}) // Empty details, not found
+
+	// Query invalid address details
+	addressRequest := &types.QueryAddressDetailsRequest{
+		Address: "invalid address",
+	}
+	addressDetails, err := suite.querier.AddressDetails(suite.goCtx, addressRequest)
+	suite.Require().Error(err) // Failed in parsing acc address
+
+	addressRequest = &types.QueryAddressDetailsRequest{
+		Address: anyUser.String(),
+	}
+	addressDetails, err = suite.querier.AddressDetails(suite.goCtx, addressRequest)
+	suite.Require().NoError(err)
+	suite.Require().Equal(addressDetails.Data, &types.AddressDetails{})
+
+	// Query invalid verification details
+	verificationRequest := &types.QueryVerificationDetailsRequest{
+		VerificationID: "invalid verification id",
+	}
+	verificationDetails, err := suite.querier.VerificationDetails(suite.goCtx, verificationRequest)
+	suite.Require().NoError(err)
+	suite.Require().Equal(verificationDetails.Details, &types.VerificationDetails{})
+}

--- a/x/compliance/module.go
+++ b/x/compliance/module.go
@@ -104,7 +104,7 @@ func NewAppModule(
 // RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.Querier{Keeper: am.keeper})
 }
 
 // RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted)

--- a/x/compliance/types/keys.go
+++ b/x/compliance/types/keys.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/kv"
+)
+
 const (
 	// ModuleName defines the module name
 	ModuleName = "compliance"
@@ -25,3 +30,13 @@ var (
 	KeyPrefixAddressDetails      = []byte{prefixAddressDetails}
 	KeyPrefixVerificationDetails = []byte{prefixVerificationDetails}
 )
+
+func AccAddressFromKey(key []byte) sdk.AccAddress {
+	kv.AssertKeyAtLeastLength(key, 1)
+	return key[1:]
+}
+
+func VerificationIdFromKey(key []byte) []byte {
+	kv.AssertKeyAtLeastLength(key, 1)
+	return key[1:]
+}

--- a/x/evm/keeper/sgxvm_connector.go
+++ b/x/evm/keeper/sgxvm_connector.go
@@ -246,7 +246,7 @@ func (q Connector) AddVerificationDetails(req *librustgo.CosmosRequest_AddVerifi
 		OriginalData:        req.AddVerificationDetails.ProofData,
 	}
 
-	if err := q.EVMKeeper.ComplianceKeeper.AddVerificationDetails(q.Context, userAddress, verificationType, verificationDetails); err != nil {
+	if _, err := q.EVMKeeper.ComplianceKeeper.AddVerificationDetails(q.Context, userAddress, verificationType, verificationDetails); err != nil {
 		return nil, err
 	}
 

--- a/x/evm/types/interfaces.go
+++ b/x/evm/types/interfaces.go
@@ -73,7 +73,7 @@ type DIDKeeper interface {
 
 // ComplianceKeeper
 type ComplianceKeeper interface {
-	AddVerificationDetails(ctx sdk.Context, userAddress sdk.Address, verificationType compliancetypes.VerificationType, details *compliancetypes.VerificationDetails) error
+	AddVerificationDetails(ctx sdk.Context, userAddress sdk.Address, verificationType compliancetypes.VerificationType, details *compliancetypes.VerificationDetails) ([]byte, error)
 	HasVerificationOfType(ctx sdk.Context, userAddress sdk.Address, expectedType compliancetypes.VerificationType, expectedIssuers []sdk.Address) (bool, error)
 }
 


### PR DESCRIPTION
Changelog:
- Add validation checks in `InitGenesis`.
- Remove address details when `RemoveIssuerDetails`.
- Do not return verifications of removed issuer when `GetAddressDetails`, `GetVerificationDetails`, and remove them on the other hand.
- Do not allow to add verification details if issuer is not valid.
- Set verification status as false if newly set issuer details `HandleSetIssuerDetails`.
- Add verification id as return value when `AddVerificationDetails`.
- Return empty `VerificationDetails` in `GetVerificationDetails` when not found without error.
- Define `Querier` with compliance keeper.
- Add unit tests for `InitGenesis`/`ExportGenesis`, `MsgServer`, `Querier`.